### PR TITLE
Add-detail-page-ouside-ins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ A React-based Pokemon dashboard application implementing advanced performance op
 
 **Package Manager**: npm 10.6.5 (required)
 
+**Dependency Constraint**: All dependencies are **pinned to exact versions** (no `^` or `~`). This ensures consistency across all environments and builds. Never add `^` or `~` prefixes when installing new packages. Use `npm install <package>@version` with exact version.
+
 ## Common Commands
 
 ### Development
@@ -33,6 +35,22 @@ vitest --ui       # Open Vitest UI
 ```bash
 npm lint         # Run ESLint (TypeScript files)
 npm format       # Format code with Prettier
+```
+
+### Installing Dependencies
+
+**Workflow for adding new packages**:
+
+1. Install the latest version: `npm install package-name`
+2. Manually remove `^` and `~` prefixes in `package.json` to pin to exact version
+
+**Example**:
+
+```bash
+npm install lodash
+# This adds "lodash": "^4.17.21" in package.json
+# ↓ manually change to:
+# "lodash": "4.17.21"
 ```
 
 ### Running Single Test
@@ -190,6 +208,299 @@ const PokemonListBad = () => {
 
 - React Router's `useSearchParams` for Pokemon type selection
 - No global state management (Redux/MobX)
+
+**8. Shared Infrastructure Agnosticism**
+
+Shared infrastructure (`/src/infrastructure/`) must NEVER know about specific features (`/src/features/`).
+
+**Shared infrastructure MUST NOT:**
+
+- ❌ Import from feature directories
+- ❌ Reference specific slice names, action types, or feature properties
+- ❌ Have hard-coded feature logic
+- ❌ Assume feature implementation details
+- ❌ Create tight coupling to feature structure
+
+**Instead, use configuration-based patterns:**
+
+```typescript
+// ❌ BAD: Infrastructure knows about 'listPreferences' feature
+export const middleware = (store) => (next) => (action) => {
+  const result = next(action);
+  if (action.type?.startsWith("listPreferences/")) {
+    // ← Hard-coded feature name
+    const dataToSave = {
+      listPreferences: store.getState().listPreferences, // ← Feature-specific
+    };
+    localStorage.setItem(key, JSON.stringify(dataToSave));
+  }
+  return result;
+};
+
+// ✅ GOOD: Infrastructure accepts configuration from feature layer
+export const createPersistenceMiddleware = (config: {
+  storageKey: string;
+  slicesToPersist: string[]; // Features decide what to persist
+}) => {
+  return (store) => (next) => (action) => {
+    const result = next(action);
+    if (
+      config.slicesToPersist.some((slice) =>
+        action.type?.startsWith(`${slice}/`)
+      )
+    ) {
+      const dataToSave = config.slicesToPersist.reduce(
+        (acc, slice) => ({
+          ...acc,
+          [slice]: store.getState()[slice],
+        }),
+        {}
+      );
+      localStorage.setItem(config.storageKey, JSON.stringify(dataToSave));
+    }
+    return result;
+  };
+};
+
+// Feature layer configures infrastructure
+const persistenceMiddleware = createPersistenceMiddleware({
+  storageKey: "__pokemon-dashboard__",
+  slicesToPersist: ["listPreferences"],
+});
+```
+
+**Why this matters:**
+
+- **Reusability**: Same middleware works for ANY feature
+- **Decoupling**: Shared code independent from feature changes
+- **Testability**: Infrastructure tested without feature knowledge
+- **Scalability**: Adding new features doesn't modify shared infrastructure
+- **Clean Architecture**: Respects Dependency Rule
+
+## Pre-Flight Checklists
+
+Use these checklists BEFORE implementing code to ensure compliance with project constraints.
+
+### Before Writing ANY Code (MANDATORY)
+
+**⚠️ STOP AND READ CLAUDE.md FIRST ⚠️**
+
+Before touching ANY file, complete this checklist:
+
+- [ ] I have read the relevant sections of CLAUDE.md for this task
+- [ ] I understand which architectural layer I'm working in (Domain/Application/Infrastructure/UI)
+- [ ] I know what testing patterns apply to this layer
+- [ ] I have identified which constraints apply to my changes
+- [ ] I can explain why my approach follows the guidelines
+
+**If you answered NO to any of these, STOP and read CLAUDE.md thoroughly first.**
+
+### Before Creating Test Helpers
+
+**Helper Scope Verification:**
+
+- [ ] Does this helper use `userEvent` methods (`click`, `type`, `hover`)? If NO → Don't create it
+- [ ] Does this helper simulate a user action? If NO → Don't create it
+- [ ] Am I extracting DOM queries, `waitFor()`, or assertions? If YES → Don't create it
+- [ ] Does this helper combine element finding + user interaction? If NO → It's not a valid helper
+
+**Valid Helper Pattern:**
+
+```typescript
+// ✅ VALID: userEvent action
+export const clickTypeButton = async (typeName: string) => {
+  const user = userEvent.setup();
+  const button = await screen.findByRole("button", { name: new RegExp(typeName, "i") });
+  await user.click(button);
+};
+
+// ❌ INVALID: DOM query without userEvent
+export const getTypeSection = () => {
+  return screen.getByRole("main");
+};
+
+// ❌ INVALID: waitFor wrapper
+export const waitForList = () => {
+  return waitFor(() => { ... });
+};
+```
+
+**Remember:** Only `userEvent` actions belong in helpers. Everything else stays in the test.
+
+### Before Implementing Shared Infrastructure (`/src/infrastructure/`)
+
+**Feature Agnosticism Check:**
+
+- [ ] Does my code import from `/src/features/`? If YES → Refactor to accept configuration instead
+- [ ] Does my code reference specific slice names (e.g., `listPreferences`)? If YES → Use generic string parameters
+- [ ] Does my code assume feature implementation details? If YES → Move to feature layer
+- [ ] Can this code work with ANY feature configuration? If NO → It's not truly shared
+
+**Example Red Flag:**
+
+```typescript
+// ❌ BAD: Hard-coded feature knowledge
+if (action.type.startsWith("listPreferences/")) {
+}
+
+// ✅ GOOD: Configurable
+if (
+  config.slicesToPersist.some((slice) => action.type.startsWith(`${slice}/`))
+) {
+}
+```
+
+### Before Writing Tests
+
+**Test Agnosticism Check:**
+
+- [ ] Do my tests reference specific feature names? If YES → Use generic test data
+- [ ] Are test values hard-coded feature properties (e.g., `sortByHeight`)? If YES → Use generic names
+- [ ] Do tests prove the code works with ANY input, not just current features? If NO → Refactor tests
+- [ ] Are tests for shared infrastructure fully feature-agnostic? If NO → Fix immediately
+
+**Example Red Flag:**
+
+```typescript
+// ❌ BAD: Feature-specific test data
+const SLICES_TO_PERSIST = ["listPreferences"];
+mockState = { listPreferences: { sortByHeight: true } };
+
+// ✅ GOOD: Generic test data
+const SLICES_TO_PERSIST = ["testSlice"];
+mockState = { testSlice: { testProp: true } };
+```
+
+**Blackbox Principle Check:**
+
+- [ ] Am I testing browser APIs (localStorage, fetch, window)? If YES → Mock them completely
+- [ ] Am I testing Redux internals (dispatch, reducers, state updates)? If YES → Mock Redux components
+- [ ] Am I testing my code's logic, not the library's behavior? If NO → Add mocks
+- [ ] Do my tests prove I call external APIs correctly, not that APIs work? If NO → Refactor
+
+**Example Red Flag:**
+
+```typescript
+// ❌ BAD: Testing localStorage's JSON behavior
+localStorage.setItem("key", JSON.stringify(data));
+expect(JSON.parse(localStorage.getItem("key"))).toEqual(data);
+
+// ✅ GOOD: Mocking localStorage, testing MY code
+const setItemSpy = vi
+  .spyOn(Storage.prototype, "setItem")
+  .mockImplementation(() => {});
+myFunction();
+expect(setItemSpy).toHaveBeenCalledWith("key", JSON.stringify(data));
+```
+
+**No Feature-Specific Details Check:**
+
+- [ ] Are action types hard-coded as `'featureName/action'`? If YES → Use generic names
+- [ ] Are state shapes tied to specific features? If YES → Use generic object structures
+- [ ] Could a colleague understand the test without knowing about Pokemon features? If NO → Make it generic
+
+### Before Writing Feature Code
+
+**Architecture Check:**
+
+- [ ] Am I putting business logic in components? If YES → Move to hooks/use-cases
+- [ ] Am I directly accessing infrastructure in components? If YES → Move to hooks
+- [ ] Are my components humble (only orchestrating hooks)? If NO → Extract logic
+- [ ] Did I follow TDD (tests first, then code)? If NO → Write tests now
+
+**Dependency Injection Check:**
+
+- [ ] Am I hard-coding dependencies instead of passing them? If YES → Add DI
+- [ ] Can I test this without rendering React? If NO → Add DI
+- [ ] Are dependencies configurable? If NO → Add configuration parameter
+
+**Example Red Flag:**
+
+```typescript
+// ❌ BAD: Hard-coded dependency
+const repository = new HttpPokemonRepository();
+
+// ✅ GOOD: Injected dependency
+function usePokemonList(repository: PokemonRepository) {}
+```
+
+### Quick Implementation Ritual
+
+Before you start coding:
+
+1. **Read relevant constraints** - What rules apply to this code?
+2. **State them explicitly** - Write down which constraints you must follow
+3. **Design for those constraints** - Shape your code to satisfy them
+4. **Implement with verification** - After writing, verify constraint compliance
+
+This ritual takes 2 minutes but prevents hours of rework.
+
+## YAGNI Principle (You Aren't Gonna Need It)
+
+**Core Rule:** Only implement what is **strictly necessary** to solve the current problem. Stay within scope.
+
+**What we build:**
+
+- ✅ Features explicitly requested or required
+- ✅ Infrastructure for scalability, flexibility, and agnosticism (e.g., configuration-based middleware)
+- ✅ Risk mitigation (error handling, validation)
+
+**What we DON'T build:**
+
+- ❌ "Nice to have" features
+- ❌ Speculative functionality ("we might need this later")
+- ❌ Extra actions, selectors, or helpers not currently used
+- ❌ Abstractions before they're needed
+
+**Example - Redux Slice:**
+
+```typescript
+// ❌ BAD: Over-engineered for future use
+export const slice = createSlice({
+  name: "preferences",
+  initialState: { sortByHeight: false, sortByName: false, theme: "light" },
+  reducers: {
+    toggleSortByHeight: (state) => {
+      state.sortByHeight = !state.sortByHeight;
+    },
+    toggleSortByName: (state) => {
+      state.sortByName = !state.sortByName;
+    }, // NOT NEEDED
+    setSortByHeight: (state, action) => {
+      state.sortByHeight = action.payload;
+    }, // NOT NEEDED
+    resetPreferences: () => initialState, // NOT NEEDED
+    setTheme: (state, action) => {
+      state.theme = action.payload;
+    }, // NOT NEEDED
+  },
+});
+
+// ✅ GOOD: Only what we need NOW
+export const slice = createSlice({
+  name: "preferences",
+  initialState: { sortByHeight: false },
+  reducers: {
+    toggleSortByHeight: (state) => {
+      state.sortByHeight = !state.sortByHeight;
+    },
+    // Add more ONLY when requirements arrive
+  },
+});
+```
+
+**When to add more:**
+
+- When a new requirement explicitly asks for it
+- Not before
+
+**Benefits:**
+
+- Less code to maintain
+- Faster implementation
+- Easier to test
+- Simpler to understand
+- No unused code
 
 ## Custom Virtual Scrolling System
 
@@ -371,6 +682,45 @@ beforeEach(() => {
 - TDD approach with unit tests catches logic errors early
 - Pages tests verify component composition works correctly
 - External E2E tools add complexity without proportional value
+```
+
+### Testing Constraint: Blackbox Principle
+
+**Do NOT test blackboxes, browser APIs, or third-party libraries.**
+
+We only test **our implementation decisions** and **our project code**. Never test:
+
+- ❌ Browser APIs (localStorage, sessionStorage, fetch, etc.)
+- ❌ Third-party libraries (Redux, React Router, Tailwind, etc.)
+- ❌ Framework internals (Redux dispatch, state updates, reducers)
+- ❌ Library behavior
+
+**Instead, mock them completely:**
+
+- ✅ Mock browser APIs: `vi.spyOn(Storage.prototype, 'setItem')`
+- ✅ Mock Redux internals: mock `store`, `next`, `action`
+- ✅ Test only that we call them with correct parameters
+- ✅ Test that we handle errors they might throw
+- ✅ Test our code's logic, not their code's logic
+
+**Example (Wrong):**
+
+```typescript
+// ❌ This tests localStorage's JSON behavior, not our code
+localStorage.setItem("key", JSON.stringify(data));
+const loaded = JSON.parse(localStorage.getItem("key"));
+expect(loaded).toEqual(data); // Tests JSON + localStorage
+```
+
+**Example (Correct):**
+
+```typescript
+// ✅ This tests only our code's behavior
+const setItemSpy = vi
+  .spyOn(Storage.prototype, "setItem")
+  .mockImplementation(() => {});
+myFunction();
+expect(setItemSpy).toHaveBeenCalledWith("key", JSON.stringify(data)); // Tests our code
 ```
 
 **TDD Workflow:**
@@ -643,7 +993,9 @@ When adding new tests, always check if a mock already exists in the appropriate 
 
 14. **User-Oriented Helpers Pattern (userEvent Only)**
 
-    - Extract **all user interactions** (`userEvent` methods) into named helper functions
+    **⚠️ CRITICAL RULE: Only `userEvent` actions can be helpers. Nothing else.**
+
+    - Extract **ONLY user interactions** (`userEvent` methods) into named helper functions
     - Helpers encapsulate the complete user action (setup → find element → interact)
     - Apply to all user interactions, whether repeated or not (purpose is legibility, not DRY)
     - Name helpers from the user's perspective (what action, not implementation)
@@ -652,8 +1004,24 @@ When adding new tests, always check if a mock already exists in the appropriate 
     **Scope:**
 
     - ✅ Extract: `await user.click()`, `await user.type()`, `await user.hover()`, etc.
-    - ❌ Don't extract: DOM queries, `waitFor()`, `findByRole()`, assertions
+    - ❌ **NEVER extract**: DOM queries, `waitFor()`, `findByRole()`, `getByRole()`, `within()`, assertions
     - ✅ Combine element queries with userEvent actions inside the helper
+
+    **What NOT to Extract (Keep in Tests):**
+
+    ```typescript
+    // ❌ DON'T extract DOM queries
+    export const getTypeSection = () => screen.getByRole("main");
+
+    // ❌ DON'T extract waitFor
+    export const waitForList = () => waitFor(() => { ... });
+
+    // ❌ DON'T extract assertions
+    export const checkItemExists = (name) => expect(screen.getByText(name)).toBeInTheDocument();
+
+    // ❌ DON'T extract element finding
+    export const findButton = () => screen.findByRole("button");
+    ```
 
     **Benefits:**
 

--- a/src/features/pokemon-detail/PokemonDetailTypes.tsx
+++ b/src/features/pokemon-detail/PokemonDetailTypes.tsx
@@ -40,7 +40,10 @@ const PokemonDetailTypes = ({ types }: PokemonTypesProps) => {
   };
 
   return (
-    <section className="bg-stone-600  rounded-lg p-4 mb-4">
+    <section
+      className="bg-stone-600  rounded-lg p-4 mb-4"
+      aria-labelledby="pokemon-type-list-heading"
+    >
       <h2
         className="mb-2 text-lg l:text-xl xl:text-2xl font-semibold"
         id="pokemon-type-list-heading"

--- a/src/features/pokemon-detail/PokemonEvolutions.tsx
+++ b/src/features/pokemon-detail/PokemonEvolutions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { paths } from "../../lib/constants";
 import { IEvolutionChainLink } from "./entities";
 

--- a/src/pages/Detail/__tests__/Detail.test.tsx
+++ b/src/pages/Detail/__tests__/Detail.test.tsx
@@ -4,7 +4,7 @@ import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import Detail from "../Detail";
 import { clickTypeButton, clickEvolutionLink } from "./helpers";
 
-const renderDetailPage = (pokemonName: string) => {
+const renderDetailPageWithRoute = (pokemonName: string) => {
   const router = createMemoryRouter(
     [
       {
@@ -22,7 +22,7 @@ const renderDetailPage = (pokemonName: string) => {
 };
 
 it("renders the initial elements", async () => {
-  renderDetailPage("bulbasaur");
+  renderDetailPageWithRoute("bulbasaur");
 
   const header = screen.getByRole("banner");
   const heading = within(header).getByRole("heading", {
@@ -88,7 +88,7 @@ it("renders the initial elements", async () => {
 });
 
 it("displays evolution links excluding current pokemon", async () => {
-  renderDetailPage("bulbasaur");
+  renderDetailPageWithRoute("bulbasaur");
 
   const main = screen.getByRole("main");
   const article = within(main).getByRole("article");
@@ -124,7 +124,7 @@ it("displays evolution links excluding current pokemon", async () => {
 });
 
 it("navigates to evolution pokemon when clicking evolution link", async () => {
-  renderDetailPage("bulbasaur");
+  renderDetailPageWithRoute("bulbasaur");
 
   // Wait for page to load
   await waitFor(async () => {
@@ -167,7 +167,7 @@ it("navigates to evolution pokemon when clicking evolution link", async () => {
 });
 
 it("displays list of pokemon when type button is clicked", async () => {
-  renderDetailPage("bulbasaur");
+  renderDetailPageWithRoute("bulbasaur");
 
   const main = screen.getByRole("main");
   const article = within(main).getByRole("article");
@@ -210,7 +210,7 @@ it("displays list of pokemon when type button is clicked", async () => {
 });
 
 it("displays different list when different type button is clicked", async () => {
-  renderDetailPage("bulbasaur");
+  renderDetailPageWithRoute("bulbasaur");
 
   const main = screen.getByRole("main");
   const article = within(main).getByRole("article");
@@ -253,7 +253,7 @@ it("displays different list when different type button is clicked", async () => 
 });
 
 it("renders pokemon stats in SVG graph", async () => {
-  renderDetailPage("bulbasaur");
+  renderDetailPageWithRoute("bulbasaur");
 
   const main = screen.getByRole("main");
   const article = within(main).getByRole("article");

--- a/src/pages/Detail/__tests__/Detail.test.tsx
+++ b/src/pages/Detail/__tests__/Detail.test.tsx
@@ -1,0 +1,282 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { expect, it } from "vitest";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import Detail from "../Detail";
+import { clickTypeButton, clickEvolutionLink } from "./helpers";
+
+const renderDetailPage = (pokemonName: string) => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/:name",
+        element: <Detail />,
+      },
+    ],
+    {
+      initialEntries: [`/${pokemonName}`],
+      initialIndex: 0,
+    }
+  );
+
+  return render(<RouterProvider router={router} />);
+};
+
+it("renders the initial elements", async () => {
+  renderDetailPage("bulbasaur");
+
+  const header = screen.getByRole("banner");
+  const heading = within(header).getByRole("heading", {
+    name: /bulbasaur/i,
+    level: 1,
+  });
+
+  expect(heading).toBeInTheDocument();
+
+  const homeLink = within(header).getByRole("link", {
+    name: /home/i,
+  });
+  expect(homeLink).toBeInTheDocument();
+  expect(homeLink).toHaveAttribute("href", "/");
+
+  const main = screen.getByRole("main");
+  const article = within(main).getByRole("article");
+
+  // Wait for pokemon image to load
+  await waitFor(async () => {
+    const image = await within(article).findByRole("img", {
+      name: /bulbasaur/i,
+    });
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute(
+      "src",
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png"
+    );
+  });
+
+  // Wait for stats section to appear
+  await waitFor(async () => {
+    const statsHeading = await within(article).findByRole("heading", {
+      name: /stats:/i,
+      level: 2,
+    });
+    expect(statsHeading).toBeInTheDocument();
+
+    // Stats should be rendered in SVG
+    const svg = within(article).getByRole("img", { hidden: true });
+    expect(svg).toBeInTheDocument();
+  });
+
+  // Wait for types section to appear
+  await waitFor(async () => {
+    const typesHeading = await within(article).findByRole("heading", {
+      name: /types:/i,
+      level: 2,
+    });
+    expect(typesHeading).toBeInTheDocument();
+
+    // Type buttons should be rendered
+    const grassButton = await within(article).findByRole("button", {
+      name: /grass/i,
+    });
+    expect(grassButton).toBeInTheDocument();
+
+    const poisonButton = await within(article).findByRole("button", {
+      name: /poison/i,
+    });
+    expect(poisonButton).toBeInTheDocument();
+  });
+});
+
+it("displays evolution links excluding current pokemon", async () => {
+  renderDetailPage("bulbasaur");
+
+  const main = screen.getByRole("main");
+  const article = within(main).getByRole("article");
+
+  // Wait for evolutions section to appear
+  await waitFor(async () => {
+    const evolutionsHeading = await within(article).findByRole("heading", {
+      name: /evolutions:/i,
+      level: 2,
+    });
+    expect(evolutionsHeading).toBeInTheDocument();
+  });
+
+  // Check that evolution links are present
+  const ivysaurLink = await within(article).findByRole("link", {
+    name: /ivysaur/i,
+  });
+  expect(ivysaurLink).toBeInTheDocument();
+  expect(ivysaurLink).toHaveAttribute("href", "/ivysaur");
+
+  const venusaurLink = await within(article).findByRole("link", {
+    name: /venusaur/i,
+  });
+  expect(venusaurLink).toBeInTheDocument();
+  expect(venusaurLink).toHaveAttribute("href", "/venusaur");
+
+  // Current pokemon (bulbasaur) should NOT be in the evolution links
+  const bulbasaurLinks = within(article).queryAllByRole("link", {
+    name: /bulbasaur/i,
+  });
+  // There should be no evolution link for bulbasaur (only home link exists)
+  expect(bulbasaurLinks.length).toBe(0);
+});
+
+it("navigates to evolution pokemon when clicking evolution link", async () => {
+  renderDetailPage("bulbasaur");
+
+  // Wait for page to load
+  await waitFor(async () => {
+    const heading = await screen.findByRole("heading", {
+      name: /bulbasaur/i,
+      level: 1,
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  // Wait for evolution links to appear
+  await waitFor(async () => {
+    const ivysaurLink = await screen.findByRole("link", {
+      name: /ivysaur/i,
+    });
+    expect(ivysaurLink).toBeInTheDocument();
+  });
+
+  await clickEvolutionLink("ivysaur");
+
+  // Check that the heading updates to ivysaur
+  await waitFor(async () => {
+    const ivysaurHeading = await screen.findByRole("heading", {
+      name: /ivysaur/i,
+      level: 1,
+    });
+    expect(ivysaurHeading).toBeInTheDocument();
+  });
+
+  // Check that ivysaur's image is displayed
+  await waitFor(async () => {
+    const image = await screen.findByRole("img", {
+      name: /ivysaur/i,
+    });
+    expect(image).toHaveAttribute(
+      "src",
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/2.png"
+    );
+  });
+});
+
+it("displays list of pokemon when type button is clicked", async () => {
+  renderDetailPage("bulbasaur");
+
+  const main = screen.getByRole("main");
+  const article = within(main).getByRole("article");
+
+  // Wait for types section to appear
+  await waitFor(async () => {
+    const typesHeading = await within(article).findByRole("heading", {
+      name: /types:/i,
+      level: 2,
+    });
+    expect(typesHeading).toBeInTheDocument();
+  });
+
+  await clickTypeButton("grass");
+
+  // Wait for pokemon list to appear in the types section
+  await waitFor(() => {
+    const typeSection = within(article).getByRole("region", {
+      name: /types:/i,
+    });
+    const bulbasaurListItem = within(typeSection).getByText(/bulbasaur/i);
+    expect(bulbasaurListItem).toBeInTheDocument();
+  });
+
+  const typeSection = within(article).getByRole("region", {
+    name: /types:/i,
+  });
+
+  const ivysaurListItem = within(typeSection).getByText(/ivysaur/i);
+  expect(ivysaurListItem).toBeInTheDocument();
+
+  const venusaurListItem = within(typeSection).getByText(/venusaur/i);
+  expect(venusaurListItem).toBeInTheDocument();
+
+  const oddishListItem = within(typeSection).getByText(/oddish/i);
+  expect(oddishListItem).toBeInTheDocument();
+
+  const gloomListItem = within(typeSection).getByText(/gloom/i);
+  expect(gloomListItem).toBeInTheDocument();
+});
+
+it("displays different list when different type button is clicked", async () => {
+  renderDetailPage("bulbasaur");
+
+  const main = screen.getByRole("main");
+  const article = within(main).getByRole("article");
+
+  // Wait for types section to appear
+  await waitFor(async () => {
+    const typesHeading = await within(article).findByRole("heading", {
+      name: /types:/i,
+      level: 2,
+    });
+    expect(typesHeading).toBeInTheDocument();
+  });
+
+  await clickTypeButton("poison");
+
+  // Wait for pokemon list to appear in the types section
+  await waitFor(() => {
+    const typeSection = within(article).getByRole("region", {
+      name: /types:/i,
+    });
+    const bulbasaurListItem = within(typeSection).getByText(/bulbasaur/i);
+    expect(bulbasaurListItem).toBeInTheDocument();
+  });
+
+  const typeSection = within(article).getByRole("region", {
+    name: /types:/i,
+  });
+
+  const ivysaurListItem = within(typeSection).getByText(/ivysaur/i);
+  expect(ivysaurListItem).toBeInTheDocument();
+
+  const venusaurListItem = within(typeSection).getByText(/venusaur/i);
+  expect(venusaurListItem).toBeInTheDocument();
+
+  const weedleListItem = within(typeSection).getByText(/weedle/i);
+  expect(weedleListItem).toBeInTheDocument();
+
+  const kakunaListItem = within(typeSection).getByText(/kakuna/i);
+  expect(kakunaListItem).toBeInTheDocument();
+});
+
+it("renders pokemon stats in SVG graph", async () => {
+  renderDetailPage("bulbasaur");
+
+  const main = screen.getByRole("main");
+  const article = within(main).getByRole("article");
+
+  // Wait for stats section to appear
+  await waitFor(async () => {
+    const statsHeading = await within(article).findByRole("heading", {
+      name: /stats:/i,
+      level: 2,
+    });
+    expect(statsHeading).toBeInTheDocument();
+  });
+
+  // Check that SVG is rendered
+  await waitFor(() => {
+    const svgs = article.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+  });
+
+  // Check that SVG has the correct attributes
+  const svg = article.querySelector("svg");
+  expect(svg).toBeInTheDocument();
+  expect(svg?.tagName.toLowerCase()).toBe("svg");
+  expect(svg).toHaveAttribute("viewBox", "0 0 500 300");
+  expect(svg).toHaveAttribute("preserveAspectRatio", "xMinYMin meet");
+});

--- a/src/pages/Detail/__tests__/helpers.ts
+++ b/src/pages/Detail/__tests__/helpers.ts
@@ -1,0 +1,22 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+export const clickTypeButton = async (typeName: string) => {
+  const user = userEvent.setup();
+
+  const typeButton = await screen.findByRole("button", {
+    name: new RegExp(typeName, "i"),
+  });
+
+  await user.click(typeButton);
+};
+
+export const clickEvolutionLink = async (pokemonName: string) => {
+  const user = userEvent.setup();
+
+  const evolutionLink = await screen.findByRole("link", {
+    name: new RegExp(pokemonName, "i"),
+  });
+
+  await user.click(evolutionLink);
+};

--- a/src/pages/Detail/__tests__/mocks.ts
+++ b/src/pages/Detail/__tests__/mocks.ts
@@ -1,0 +1,532 @@
+export const bulbasaurDetailMock = {
+  abilities: [
+    {
+      ability: {
+        name: "overgrow",
+        url: "https://pokeapi.co/api/v2/ability/65/",
+      },
+      is_hidden: false,
+      slot: 1,
+    },
+    {
+      ability: {
+        name: "chlorophyll",
+        url: "https://pokeapi.co/api/v2/ability/34/",
+      },
+      is_hidden: true,
+      slot: 3,
+    },
+  ],
+  base_experience: 64,
+  cries: {
+    latest:
+      "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/latest/1.ogg",
+    legacy:
+      "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/legacy/1.ogg",
+  },
+  forms: [
+    {
+      name: "bulbasaur",
+      url: "https://pokeapi.co/api/v2/pokemon-form/1/",
+    },
+  ],
+  game_indices: [
+    {
+      game_index: 1,
+      version: {
+        name: "red",
+        url: "https://pokeapi.co/api/v2/version/1/",
+      },
+    },
+  ],
+  height: 7,
+  held_items: [],
+  id: 1,
+  is_default: true,
+  location_area_encounters: "https://pokeapi.co/api/v2/pokemon/1/encounters",
+  moves: [],
+  name: "bulbasaur",
+  order: 1,
+  past_abilities: [],
+  past_types: [],
+  species: {
+    name: "bulbasaur",
+    url: "https://pokeapi.co/api/v2/pokemon-species/1/",
+  },
+  sprites: {
+    back_default:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/1.png",
+    back_female: null,
+    back_shiny:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/1.png",
+    back_shiny_female: null,
+    front_default:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png",
+    front_female: null,
+    front_shiny:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/1.png",
+    front_shiny_female: null,
+  },
+  stats: [
+    {
+      base_stat: 45,
+      effort: 0,
+      stat: {
+        name: "hp",
+        url: "https://pokeapi.co/api/v2/stat/1/",
+      },
+    },
+    {
+      base_stat: 49,
+      effort: 0,
+      stat: {
+        name: "attack",
+        url: "https://pokeapi.co/api/v2/stat/2/",
+      },
+    },
+    {
+      base_stat: 49,
+      effort: 0,
+      stat: {
+        name: "defense",
+        url: "https://pokeapi.co/api/v2/stat/3/",
+      },
+    },
+    {
+      base_stat: 65,
+      effort: 1,
+      stat: {
+        name: "special-attack",
+        url: "https://pokeapi.co/api/v2/stat/4/",
+      },
+    },
+    {
+      base_stat: 65,
+      effort: 0,
+      stat: {
+        name: "special-defense",
+        url: "https://pokeapi.co/api/v2/stat/5/",
+      },
+    },
+    {
+      base_stat: 45,
+      effort: 0,
+      stat: {
+        name: "speed",
+        url: "https://pokeapi.co/api/v2/stat/6/",
+      },
+    },
+  ],
+  types: [
+    {
+      slot: 1,
+      type: {
+        name: "grass",
+        url: "https://pokeapi.co/api/v2/type/12/",
+      },
+    },
+    {
+      slot: 2,
+      type: {
+        name: "poison",
+        url: "https://pokeapi.co/api/v2/type/4/",
+      },
+    },
+  ],
+  weight: 69,
+};
+
+export const bulbasaurSpeciesMock = {
+  base_happiness: 50,
+  capture_rate: 45,
+  color: {
+    name: "green",
+    url: "https://pokeapi.co/api/v2/pokemon-color/5/",
+  },
+  evolution_chain: {
+    url: "https://pokeapi.co/api/v2/evolution-chain/1/",
+  },
+  evolves_from_species: null,
+  flavor_text_entries: [],
+  form_descriptions: [],
+  forms_switchable: false,
+  gender_rate: 1,
+  genera: [],
+  generation: {
+    name: "generation-i",
+    url: "https://pokeapi.co/api/v2/generation/1/",
+  },
+  growth_rate: {
+    name: "medium-slow",
+    url: "https://pokeapi.co/api/v2/growth-rate/4/",
+  },
+  habitat: {
+    name: "grassland",
+    url: "https://pokeapi.co/api/v2/pokemon-habitat/3/",
+  },
+  has_gender_differences: false,
+  hatch_counter: 20,
+  id: 1,
+  is_baby: false,
+  is_legendary: false,
+  is_mythical: false,
+  name: "bulbasaur",
+  names: [],
+  order: 1,
+  pal_park_encounters: [],
+  pokedex_numbers: [],
+  shape: {
+    name: "quadruped",
+    url: "https://pokeapi.co/api/v2/pokemon-shape/8/",
+  },
+  varieties: [],
+};
+
+export const bulbasaurEvolutionChainMock = {
+  baby_trigger_item: null,
+  chain: {
+    evolution_details: [],
+    evolves_to: [
+      {
+        evolution_details: [
+          {
+            gender: null,
+            held_item: null,
+            item: null,
+            known_move: null,
+            known_move_type: null,
+            location: null,
+            min_affection: null,
+            min_beauty: null,
+            min_happiness: null,
+            min_level: 16,
+            needs_overworld_rain: false,
+            party_species: null,
+            party_type: null,
+            relative_physical_stats: null,
+            time_of_day: "",
+            trade_species: null,
+            trigger: {
+              name: "level-up",
+              url: "https://pokeapi.co/api/v2/evolution-trigger/1/",
+            },
+            turn_upside_down: false,
+          },
+        ],
+        evolves_to: [
+          {
+            evolution_details: [
+              {
+                gender: null,
+                held_item: null,
+                item: null,
+                known_move: null,
+                known_move_type: null,
+                location: null,
+                min_affection: null,
+                min_beauty: null,
+                min_happiness: null,
+                min_level: 32,
+                needs_overworld_rain: false,
+                party_species: null,
+                party_type: null,
+                relative_physical_stats: null,
+                time_of_day: "",
+                trade_species: null,
+                trigger: {
+                  name: "level-up",
+                  url: "https://pokeapi.co/api/v2/evolution-trigger/1/",
+                },
+                turn_upside_down: false,
+              },
+            ],
+            evolves_to: [],
+            is_baby: false,
+            species: {
+              name: "venusaur",
+              url: "https://pokeapi.co/api/v2/pokemon-species/3/",
+            },
+          },
+        ],
+        is_baby: false,
+        species: {
+          name: "ivysaur",
+          url: "https://pokeapi.co/api/v2/pokemon-species/2/",
+        },
+      },
+    ],
+    is_baby: false,
+    species: {
+      name: "bulbasaur",
+      url: "https://pokeapi.co/api/v2/pokemon-species/1/",
+    },
+  },
+  id: 1,
+};
+
+export const grassTypeListMock = {
+  pokemon: [
+    {
+      pokemon: {
+        name: "bulbasaur",
+        url: "https://pokeapi.co/api/v2/pokemon/1/",
+      },
+      slot: 1,
+    },
+    {
+      pokemon: {
+        name: "ivysaur",
+        url: "https://pokeapi.co/api/v2/pokemon/2/",
+      },
+      slot: 1,
+    },
+    {
+      pokemon: {
+        name: "venusaur",
+        url: "https://pokeapi.co/api/v2/pokemon/3/",
+      },
+      slot: 1,
+    },
+    {
+      pokemon: {
+        name: "oddish",
+        url: "https://pokeapi.co/api/v2/pokemon/43/",
+      },
+      slot: 1,
+    },
+    {
+      pokemon: {
+        name: "gloom",
+        url: "https://pokeapi.co/api/v2/pokemon/44/",
+      },
+      slot: 1,
+    },
+  ],
+};
+
+export const poisonTypeListMock = {
+  pokemon: [
+    {
+      pokemon: {
+        name: "bulbasaur",
+        url: "https://pokeapi.co/api/v2/pokemon/1/",
+      },
+      slot: 2,
+    },
+    {
+      pokemon: {
+        name: "ivysaur",
+        url: "https://pokeapi.co/api/v2/pokemon/2/",
+      },
+      slot: 2,
+    },
+    {
+      pokemon: {
+        name: "venusaur",
+        url: "https://pokeapi.co/api/v2/pokemon/3/",
+      },
+      slot: 2,
+    },
+    {
+      pokemon: {
+        name: "weedle",
+        url: "https://pokeapi.co/api/v2/pokemon/13/",
+      },
+      slot: 1,
+    },
+    {
+      pokemon: {
+        name: "kakuna",
+        url: "https://pokeapi.co/api/v2/pokemon/14/",
+      },
+      slot: 1,
+    },
+  ],
+};
+
+export const ivysaurDetailMock = {
+  abilities: [
+    {
+      ability: {
+        name: "overgrow",
+        url: "https://pokeapi.co/api/v2/ability/65/",
+      },
+      is_hidden: false,
+      slot: 1,
+    },
+    {
+      ability: {
+        name: "chlorophyll",
+        url: "https://pokeapi.co/api/v2/ability/34/",
+      },
+      is_hidden: true,
+      slot: 3,
+    },
+  ],
+  base_experience: 142,
+  cries: {
+    latest:
+      "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/latest/2.ogg",
+    legacy:
+      "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/legacy/2.ogg",
+  },
+  forms: [
+    {
+      name: "ivysaur",
+      url: "https://pokeapi.co/api/v2/pokemon-form/2/",
+    },
+  ],
+  game_indices: [
+    {
+      game_index: 2,
+      version: {
+        name: "red",
+        url: "https://pokeapi.co/api/v2/version/1/",
+      },
+    },
+  ],
+  height: 10,
+  held_items: [],
+  id: 2,
+  is_default: true,
+  location_area_encounters: "https://pokeapi.co/api/v2/pokemon/2/encounters",
+  moves: [],
+  name: "ivysaur",
+  order: 2,
+  past_abilities: [],
+  past_types: [],
+  species: {
+    name: "ivysaur",
+    url: "https://pokeapi.co/api/v2/pokemon-species/2/",
+  },
+  sprites: {
+    back_default:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/2.png",
+    back_female: null,
+    back_shiny:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/2.png",
+    back_shiny_female: null,
+    front_default:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/2.png",
+    front_female: null,
+    front_shiny:
+      "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/2.png",
+    front_shiny_female: null,
+  },
+  stats: [
+    {
+      base_stat: 60,
+      effort: 0,
+      stat: {
+        name: "hp",
+        url: "https://pokeapi.co/api/v2/stat/1/",
+      },
+    },
+    {
+      base_stat: 62,
+      effort: 0,
+      stat: {
+        name: "attack",
+        url: "https://pokeapi.co/api/v2/stat/2/",
+      },
+    },
+    {
+      base_stat: 63,
+      effort: 0,
+      stat: {
+        name: "defense",
+        url: "https://pokeapi.co/api/v2/stat/3/",
+      },
+    },
+    {
+      base_stat: 80,
+      effort: 1,
+      stat: {
+        name: "special-attack",
+        url: "https://pokeapi.co/api/v2/stat/4/",
+      },
+    },
+    {
+      base_stat: 80,
+      effort: 1,
+      stat: {
+        name: "special-defense",
+        url: "https://pokeapi.co/api/v2/stat/5/",
+      },
+    },
+    {
+      base_stat: 60,
+      effort: 0,
+      stat: {
+        name: "speed",
+        url: "https://pokeapi.co/api/v2/stat/6/",
+      },
+    },
+  ],
+  types: [
+    {
+      slot: 1,
+      type: {
+        name: "grass",
+        url: "https://pokeapi.co/api/v2/type/12/",
+      },
+    },
+    {
+      slot: 2,
+      type: {
+        name: "poison",
+        url: "https://pokeapi.co/api/v2/type/4/",
+      },
+    },
+  ],
+  weight: 130,
+};
+
+export const ivysaurSpeciesMock = {
+  base_happiness: 50,
+  capture_rate: 45,
+  color: {
+    name: "green",
+    url: "https://pokeapi.co/api/v2/pokemon-color/5/",
+  },
+  evolution_chain: {
+    url: "https://pokeapi.co/api/v2/evolution-chain/1/",
+  },
+  evolves_from_species: {
+    name: "bulbasaur",
+    url: "https://pokeapi.co/api/v2/pokemon-species/1/",
+  },
+  flavor_text_entries: [],
+  form_descriptions: [],
+  forms_switchable: false,
+  gender_rate: 1,
+  genera: [],
+  generation: {
+    name: "generation-i",
+    url: "https://pokeapi.co/api/v2/generation/1/",
+  },
+  growth_rate: {
+    name: "medium-slow",
+    url: "https://pokeapi.co/api/v2/growth-rate/4/",
+  },
+  habitat: {
+    name: "grassland",
+    url: "https://pokeapi.co/api/v2/pokemon-habitat/3/",
+  },
+  has_gender_differences: false,
+  hatch_counter: 20,
+  id: 2,
+  is_baby: false,
+  is_legendary: false,
+  is_mythical: false,
+  name: "ivysaur",
+  names: [],
+  order: 2,
+  pal_park_encounters: [],
+  pokedex_numbers: [],
+  shape: {
+    name: "quadruped",
+    url: "https://pokeapi.co/api/v2/pokemon-shape/8/",
+  },
+  varieties: [],
+};

--- a/src/pages/Detail/__tests__/setupTests.ts
+++ b/src/pages/Detail/__tests__/setupTests.ts
@@ -1,0 +1,75 @@
+import { beforeEach, vi, afterEach } from "vitest";
+import {
+  bulbasaurDetailMock,
+  bulbasaurSpeciesMock,
+  bulbasaurEvolutionChainMock,
+  grassTypeListMock,
+  poisonTypeListMock,
+  ivysaurDetailMock,
+  ivysaurSpeciesMock,
+} from "./mocks";
+
+beforeEach(() => {
+  // Store any existing mock to chain with it
+  const existingFetch = globalThis.fetch;
+
+  globalThis.fetch = vi.fn(async (url: string) => {
+    // Detail page specific mocks
+    if (url.includes("/pokemon/bulbasaur")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => bulbasaurDetailMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon/ivysaur")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ivysaurDetailMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon-species/1")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => bulbasaurSpeciesMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon-species/2")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ivysaurSpeciesMock,
+      }) as any;
+    }
+    if (url.includes("/evolution-chain/1")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => bulbasaurEvolutionChainMock,
+      }) as any;
+    }
+    if (url.includes("/type/grass")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => grassTypeListMock,
+      }) as any;
+    }
+    if (url.includes("/type/poison")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => poisonTypeListMock,
+      }) as any;
+    }
+
+    // Fall back to existing mock if there is one
+    if (existingFetch && typeof existingFetch === "function") {
+      return existingFetch(url);
+    }
+
+    // If no match, return empty response
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({}),
+    }) as any;
+  }) as any;
+});
+afterEach(() => {
+  vi.resetAllMocks();
+});

--- a/src/pages/Home/__tests__/setupTests.ts
+++ b/src/pages/Home/__tests__/setupTests.ts
@@ -12,42 +12,81 @@ import {
 } from "./mocks";
 
 beforeEach(() => {
-  global.fetch = vi.fn((url: string) =>
-    Promise.resolve({
-      ok: true,
-      json: async () => {
-        if (url.includes("/type/normal")) {
-          return listByTypeNormalMock;
-        }
-        if (url.includes("/type/fire")) {
-          return listByTypeFireMock;
-        }
-        if (url.includes("/type/")) {
-          return { results: typesMock };
-        }
-        if (url.includes("/pokemon/pidgey")) {
-          return pidgeyMock;
-        }
-        if (url.includes("/pokemon/pidgeotto")) {
-          return pidgeottoMock;
-        }
-        if (url.includes("/pokemon/pidgeot")) {
-          return pidgeotMock;
-        }
-        if (url.includes("/pokemon/charmander")) {
-          return charmanderSimpleMock;
-        }
-        if (url.includes("/pokemon/charmeleon")) {
-          return charmeleonSimpleMock;
-        }
-        if (url.includes("/pokemon/charizard")) {
-          return charizardSimpleMock;
-        }
+  // Store any existing mock to chain with it
+  const existingFetch = globalThis.fetch;
 
-        return {};
-      },
-    })
-  ) as any;
+  globalThis.fetch = vi.fn(async (url: string) => {
+    // Home page specific pokemon details
+    if (url.includes("/pokemon/pidgey")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => pidgeyMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon/pidgeotto")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => pidgeottoMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon/pidgeot")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => pidgeotMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon/charmander")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => charmanderSimpleMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon/charmeleon")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => charmeleonSimpleMock,
+      }) as any;
+    }
+    if (url.includes("/pokemon/charizard")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => charizardSimpleMock,
+      }) as any;
+    }
+
+    // Home page specific type lists
+    if (url.includes("/type/normal")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => listByTypeNormalMock,
+      }) as any;
+    }
+    if (url.includes("/type/fire")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => listByTypeFireMock,
+      }) as any;
+    }
+
+    // Generic type list endpoint
+    if (url.includes("/type/")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ results: typesMock }),
+      }) as any;
+    }
+
+    // Fall back to existing mock if there is one
+    if (existingFetch && typeof existingFetch === "function") {
+      return existingFetch(url);
+    }
+
+    // If no match, return empty response
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({}),
+    }) as any;
+  }) as any;
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Add Detail Page Safety Net Tests

### Overview
Implements the Detail pagecomprehensive integration tests following outside-in approach.

### Changes
- **Test Suite**: 6 integration tests covering all user interactions and page sections
- **Accessibility**: Added `aria-labelledby` to types section for semantic region identification
- **Test Infrastructure**: 
  - Created mocks, setupTests, and user action helpers
  - Implemented fallback chaining pattern for fetch mocks to prevent conflicts
  - Standardized `globalThis.fetch` usage across test files

### Testing Strategy
- Follows patterns from Home page tests (README, CLAUDE.md guidelines)
- Outside-in approach: tests user interactions from page level
- User-oriented helpers for all `userEvent` actions (click, navigation)
- Direct DOM queries kept in tests (not extracted as helpers)

### Documentation
- Updated CLAUDE.md with pre-flight checklists to prevent future test helper violations
- Added "Before Writing ANY Code" checklist requiring CLAUDE.md review
- Expanded "Before Creating Test Helpers" section with explicit examples

All tests passing ✅