### PR TITLE
Refactor-pokemon-detail-to-hexagonal-viewmodel

### DIFF
--- a/src/features/pokemon-detail/application/view-models/PokemonDetailViewModel.ts
+++ b/src/features/pokemon-detail/application/view-models/PokemonDetailViewModel.ts
@@ -1,0 +1,33 @@
+import { PokemonDetail } from "../../domain/entities/PokemonDetail";
+import { EvolutionChain } from "../../domain/entities/EvolutionChain";
+import { PokemonDetailRepository } from "../../domain/ports/PokemonDetailRepository";
+import { GetPokemonDetailUseCase } from "../use-cases/get-pokemon-detail/GetPokemonDetailUseCase";
+import { GetEvolutionChainUseCase } from "../use-cases/get-evolution-chain/GetEvolutionChainUseCase";
+
+export class PokemonDetailViewModel {
+  private readonly getPokemonDetailUseCase: GetPokemonDetailUseCase;
+  private readonly getEvolutionChainUseCase: GetEvolutionChainUseCase;
+
+  constructor(repository: PokemonDetailRepository) {
+    this.getPokemonDetailUseCase = new GetPokemonDetailUseCase(repository);
+    this.getEvolutionChainUseCase = new GetEvolutionChainUseCase(repository);
+  }
+
+  async loadPokemonDetail(name: string): Promise<PokemonDetail | null> {
+    if (!name || name.trim() === "") {
+      return null;
+    }
+    return await this.getPokemonDetailUseCase.execute(name);
+  }
+
+  async loadEvolutionChain(speciesUrl: string): Promise<EvolutionChain | null> {
+    return await this.getEvolutionChainUseCase.execute(speciesUrl);
+  }
+
+  getEvolutionsExcluding(chain: EvolutionChain | null, currentName: string): string[] {
+    if (!chain) {
+      return [];
+    }
+    return chain.getEvolutionsExcluding(currentName);
+  }
+}

--- a/src/features/pokemon-detail/application/view-models/__tests__/PokemonDetailViewModel.test.ts
+++ b/src/features/pokemon-detail/application/view-models/__tests__/PokemonDetailViewModel.test.ts
@@ -1,0 +1,67 @@
+import { it, expect } from "vitest";
+import { PokemonDetailViewModel } from "../PokemonDetailViewModel";
+import {
+  mockBulbasaurDetail,
+  mockBulbasaurEvolutionChain,
+  createMockPokemonDetailRepository,
+} from "../../../__tests__/mocks";
+
+it("loads pokemon detail by name", async () => {
+  const mockRepository = createMockPokemonDetailRepository();
+
+  const viewModel = new PokemonDetailViewModel(mockRepository);
+  const result = await viewModel.loadPokemonDetail("bulbasaur");
+
+  expect(result).toBe(mockBulbasaurDetail);
+});
+
+it("returns null when name is empty", async () => {
+  const mockRepository = createMockPokemonDetailRepository();
+  const viewModel = new PokemonDetailViewModel(mockRepository);
+
+  const result = await viewModel.loadPokemonDetail("");
+
+  expect(result).toBeNull();
+  expect(mockRepository.findByName).not.toHaveBeenCalled();
+});
+
+it("loads evolution chain from species URL", async () => {
+  const mockRepository = createMockPokemonDetailRepository();
+
+  const viewModel = new PokemonDetailViewModel(mockRepository);
+  const result = await viewModel.loadEvolutionChain(
+    "https://pokeapi.co/api/v2/pokemon-species/1/"
+  );
+
+  expect(result).toBe(mockBulbasaurEvolutionChain);
+});
+
+it("returns null evolution chain when species URL is empty", async () => {
+  const mockRepository = createMockPokemonDetailRepository();
+  const viewModel = new PokemonDetailViewModel(mockRepository);
+
+  const result = await viewModel.loadEvolutionChain("");
+
+  expect(result).toBeNull();
+});
+
+it("gets evolutions excluding current pokemon", () => {
+  const mockRepository = createMockPokemonDetailRepository();
+  const viewModel = new PokemonDetailViewModel(mockRepository);
+
+  const result = viewModel.getEvolutionsExcluding(
+    mockBulbasaurEvolutionChain,
+    "bulbasaur"
+  );
+
+  expect(result).toEqual(["ivysaur", "venusaur"]);
+});
+
+it("returns empty array when evolution chain is null", () => {
+  const mockRepository = createMockPokemonDetailRepository();
+  const viewModel = new PokemonDetailViewModel(mockRepository);
+
+  const result = viewModel.getEvolutionsExcluding(null, "bulbasaur");
+
+  expect(result).toEqual([]);
+});


### PR DESCRIPTION
### Summary
Implements the ViewModel layer for pokemon-detail feature, coordinating GetPokemonDetailUseCase and GetEvolutionChainUseCase to provide a simplified interface for the infrastructure layer.

### Key Changes
- **ViewModel**: Created `PokemonDetailViewModel` coordinating pokemon detail and evolution chain use cases with input validation
- **Use Case Delegation**: ViewModel delegates to `GetPokemonDetailUseCase` for pokemon fetching and `GetEvolutionChainUseCase` for evolution data
- **Domain Logic**: Delegates evolution filtering to `EvolutionChain.getEvolutionsExcluding()` method
- **Tests**: Added 6 ViewModel tests covering detail loading, evolution chain loading, null handling, and evolution filtering

### Impact
✅ Testability: 6 tests verify use case orchestration, input validation, and domain delegation  
✅ Maintainability: Simplified interface for React hooks layer hiding use case complexity  
✅ No breaking changes: Prepares foundation for React hook dependency injection
