### PR TITLE
Refactor-pokemon-detail-to-hexagonal-infrastructure-extend-repository

### DIFF
--- a/src/features/pokemon-detail/infrastructure/http/__tests__/HttpPokemonDetailRepository.test.ts
+++ b/src/features/pokemon-detail/infrastructure/http/__tests__/HttpPokemonDetailRepository.test.ts
@@ -7,6 +7,8 @@ import {
   speciesResponseMock,
   evolutionChainResponseMock,
   evolutionChainNoEvolutionsResponseMock,
+  pokemonByTypeGrassResponseMock,
+  pokemonByTypeEmptyResponseMock,
 } from "./mocks";
 
 let mockFetch: ReturnType<typeof vi.fn>;
@@ -76,4 +78,29 @@ it("handles pokemon with no evolutions", async () => {
   );
 
   expect(result.pokemonNames).toEqual(["ditto"]);
+});
+
+it("finds all pokemon by type", async () => {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => pokemonByTypeGrassResponseMock,
+  });
+
+  const result = await repository.findAllByType("grass");
+
+  expect(result).toHaveLength(2);
+  expect(result[0].name).toBe("bulbasaur");
+  expect(result[1].name).toBe("ivysaur");
+  expect(mockFetch).toHaveBeenCalledWith("https://pokeapi.co/api/v2/type/grass");
+});
+
+it("returns empty array when type has no pokemon", async () => {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => pokemonByTypeEmptyResponseMock,
+  });
+
+  const result = await repository.findAllByType("unknown");
+
+  expect(result).toEqual([]);
 });

--- a/src/features/pokemon-detail/infrastructure/http/__tests__/mocks.ts
+++ b/src/features/pokemon-detail/infrastructure/http/__tests__/mocks.ts
@@ -2,6 +2,7 @@ import {
   PokemonDetailResponse,
   EvolutionChainResponse,
   SpeciesResponse,
+  PokemonByTypeResponse,
 } from "../dto";
 
 export const pokemonDetailResponseMock: PokemonDetailResponse = {
@@ -47,4 +48,15 @@ export const evolutionChainNoEvolutionsResponseMock: EvolutionChainResponse = {
     species: { name: "ditto", url: "" },
     evolves_to: [],
   },
+};
+
+export const pokemonByTypeGrassResponseMock: PokemonByTypeResponse = {
+  pokemon: [
+    { pokemon: { name: "bulbasaur", url: "https://pokeapi.co/api/v2/pokemon/1/" }, slot: 1 },
+    { pokemon: { name: "ivysaur", url: "https://pokeapi.co/api/v2/pokemon/2/" }, slot: 2 },
+  ],
+};
+
+export const pokemonByTypeEmptyResponseMock: PokemonByTypeResponse = {
+  pokemon: [],
 };


### PR DESCRIPTION
## Add Missing Tests for HttpPokemonDetailRepository `findAllByType` Method

### Summary
This PR adds missing unit tests for the `HttpPokemonDetailRepository.findAllByType()` method to ensure proper handling of pokemon type lookups. Two test cases cover the happy path (grass type with 2 pokemon) and the edge case (unknown type with empty results).

### Key Changes
- **Tests**: Added `findAllByType()` test covering grass type with valid pokemon results
- **Tests**: Added edge case test for empty results when querying unknown type
- **Tests**: Added mock responses (`pokemonByTypeGrassResponseMock`, `pokemonByTypeEmptyResponseMock`) for type-based queries

### Impact
✅ Improves test coverage for pokemon type fetching functionality
✅ Validates correct mapping of PokeAPI type response to domain entities
✅ No breaking changes — purely additive test coverage