### PR TITLE
Refactor-pokemon-detail-to-hexagonal-application-usecase

### DIFF
--- a/src/features/pokemon-detail/application/use-cases/get-pokemons-by-type/GetPokemonsByTypeUseCase.ts
+++ b/src/features/pokemon-detail/application/use-cases/get-pokemons-by-type/GetPokemonsByTypeUseCase.ts
@@ -1,0 +1,14 @@
+import { PokemonReference } from "../../../../../shared/domain/value-objects";
+import { PokemonDetailRepository } from "../../../domain/ports/PokemonDetailRepository";
+
+export class GetPokemonsByTypeUseCase {
+  constructor(private readonly repository: PokemonDetailRepository) {}
+
+  async execute(typeName: string): Promise<PokemonReference[]> {
+    if (!typeName || typeName.trim() === "") {
+      throw new Error("Type name is required");
+    }
+
+    return await this.repository.findAllByType(typeName.toLowerCase());
+  }
+}

--- a/src/features/pokemon-detail/application/use-cases/get-pokemons-by-type/__tests__/GetPokemonsByTypeUseCase.test.ts
+++ b/src/features/pokemon-detail/application/use-cases/get-pokemons-by-type/__tests__/GetPokemonsByTypeUseCase.test.ts
@@ -1,0 +1,46 @@
+import { it, expect, vi } from "vitest";
+import { GetPokemonsByTypeUseCase } from "../GetPokemonsByTypeUseCase";
+import { PokemonReference } from "../../../../domain";
+import { PokemonDetailRepository } from "../../../../domain";
+
+const createMockRepository = (): PokemonDetailRepository => ({
+  findByName: vi.fn(),
+  findEvolutionChainUrl: vi.fn(),
+  findEvolutionChain: vi.fn(),
+  findAllByType: vi.fn(),
+});
+
+it("returns pokemon list for a type", async () => {
+  const mockRepository = createMockRepository();
+  const mockPokemonList = [
+    new PokemonReference("bulbasaur"),
+    new PokemonReference("ivysaur"),
+  ];
+  (mockRepository.findAllByType as ReturnType<typeof vi.fn>).mockResolvedValue(
+    mockPokemonList
+  );
+
+  const useCase = new GetPokemonsByTypeUseCase(mockRepository);
+  const result = await useCase.execute("grass");
+
+  expect(result).toBe(mockPokemonList);
+  expect(mockRepository.findAllByType).toHaveBeenCalledWith("grass");
+});
+
+it("throws error when type name is empty", async () => {
+  const mockRepository = createMockRepository();
+  const useCase = new GetPokemonsByTypeUseCase(mockRepository);
+
+  await expect(useCase.execute("")).rejects.toThrow("Type name is required");
+});
+
+it("propagates repository errors", async () => {
+  const mockRepository = createMockRepository();
+  (mockRepository.findAllByType as ReturnType<typeof vi.fn>).mockRejectedValue(
+    new Error("Network error")
+  );
+
+  const useCase = new GetPokemonsByTypeUseCase(mockRepository);
+
+  await expect(useCase.execute("grass")).rejects.toThrow("Network error");
+});


### PR DESCRIPTION
## Implement GetPokemonsByTypeUseCase for Pokemon Detail Feature

### Summary
This PR introduces the `GetPokemonsByTypeUseCase` use case to encapsulate the business logic for fetching pokemon by their type. It validates input, delegates to the repository, and includes comprehensive test coverage for happy path and error scenarios.

### Key Changes
- **Feature**: Added `GetPokemonsByTypeUseCase` class with type validation and repository delegation
- **Tests**: Added comprehensive test suite covering successful type queries, empty input validation, and error propagation
- **Validation**: Implemented required input validation to reject empty or whitespace-only type names

### Impact
✅ Provides clean application-layer abstraction for pokemon type queries
✅ Enforces input validation and consistent error handling
✅ No breaking changes — new feature addition only