### PR TITLE
Refactor pokemon detail to hexagonal ui humble-component

### DIFF
--- a/src/features/pokemon-detail/index.ts
+++ b/src/features/pokemon-detail/index.ts
@@ -1,1 +1,1 @@
-export { default as PokemonDetail } from "./PokemonDetail";
+export { PokemonDetail } from "./ui";

--- a/src/features/pokemon-detail/ui/PokemonDetail.tsx
+++ b/src/features/pokemon-detail/ui/PokemonDetail.tsx
@@ -1,6 +1,7 @@
 import usePokemonDetail from "../infrastructure/react/hooks/usePokemonDetail";
 import PokemonEvolutions from "./PokemonEvolutions";
 import PokemonStats from "./PokemonStats";
+import PokemonDetailTypes from "./PokemonDetailTypes";
 
 interface PokemonDetailProps {
   name: string;
@@ -40,7 +41,9 @@ const PokemonDetail = ({ name }: PokemonDetailProps) => {
         </div>
       </section>
 
-      {/* PokemonDetailTypes will be added after Phase 12 */}
+      {pokemonDetail.types.length > 0 && (
+        <PokemonDetailTypes types={pokemonDetail.types} />
+      )}
     </>
   );
 };

--- a/src/features/pokemon-detail/ui/PokemonDetailTypes.tsx
+++ b/src/features/pokemon-detail/ui/PokemonDetailTypes.tsx
@@ -29,7 +29,7 @@ const PokemonDetailTypes = ({ types }: PokemonDetailTypesProps) => {
             key={name}
             value={name}
             selected={selectedType === name}
-            onClick={() => selectType(name)}
+            onClick={() => selectType(name)} // TODO: memoize?
           >
             {name}
           </SelectButton>

--- a/src/features/pokemon-detail/ui/PokemonDetailTypes.tsx
+++ b/src/features/pokemon-detail/ui/PokemonDetailTypes.tsx
@@ -1,0 +1,52 @@
+import { SelectButton, SelectButtonList } from "../../../ui";
+import usePokemonsByType from "../infrastructure/react/hooks/usePokemonsByType";
+
+interface PokemonDetailTypesProps {
+  types: string[];
+}
+
+const PokemonDetailTypes = ({ types }: PokemonDetailTypesProps) => {
+  const { pokemonNames, selectedType, selectType } = usePokemonsByType();
+
+  return (
+    <section
+      className="bg-stone-600 rounded-lg p-4 mb-4"
+      aria-labelledby="pokemon-type-list-heading"
+    >
+      <h2
+        className="mb-2 text-lg l:text-xl xl:text-2xl font-semibold"
+        id="pokemon-type-list-heading"
+      >
+        Types:
+      </h2>
+      <SelectButtonList
+        aria-live="polite"
+        aria-labelledby="pokemon-type-list-heading"
+        optionNames={types}
+      >
+        {(name) => (
+          <SelectButton
+            key={name}
+            value={name}
+            selected={selectedType === name}
+            onClick={() => selectType(name)}
+          >
+            {name}
+          </SelectButton>
+        )}
+      </SelectButtonList>
+
+      {pokemonNames.length > 0 && (
+        <ul className="flex flex-wrap gap-2 mb-2 mt-4" aria-live="polite">
+          {pokemonNames.map((name) => (
+            <li className="capitalize" key={name}>
+              {name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default PokemonDetailTypes;

--- a/src/features/pokemon-detail/ui/index.ts
+++ b/src/features/pokemon-detail/ui/index.ts
@@ -1,0 +1,4 @@
+export { default as PokemonDetail } from "./PokemonDetail";
+export { default as PokemonEvolutions } from "./PokemonEvolutions";
+export { default as PokemonStats } from "./PokemonStats";
+export { default as PokemonDetailTypes } from "./PokemonDetailTypes";


### PR DESCRIPTION
# Add PokemonDetailTypes component and update exports

## Summary
Added a new PokemonDetailTypes component to display and filter Pokemon by type, following the humble component pattern. Updated feature exports to include the new component and refactored the main PokemonDetail component to integrate it.

## Key Changes
- Feature: Created PokemonDetailTypes.tsx as a humble component that delegates logic to usePokemonsByType hook
- Refactor: Updated PokemonDetail.tsx to include the new PokemonDetailTypes component
- Config: Added ui/index.ts to consolidate UI component exports
- Config: Updated feature-level index.ts to re-export from UI layer

## Impact
✅ Improved maintainability through proper component separation
✅ Enhanced developer experience with clean export structure
✅ No breaking changes - all existing functionality preserved