### PR TITLE
Filter by name

### DIFF
--- a/docs/GUIDE_FILTER_BY_NAME.md
+++ b/docs/GUIDE_FILTER_BY_NAME.md
@@ -1,0 +1,187 @@
+# Filter by Name: Implementation Rationale
+
+## Context & Problem
+
+The Pokemon list displays all pokemon of a selected type. When a type has many pokemon (e.g., Normal has 100+), the user needs a way to quickly find a specific one by name. The filter is a text input that narrows the visible list client-side — no new API requests are made.
+
+---
+
+## Key Decisions
+
+### 1. Local state, not Redux
+
+`filterByName` lives as `useState("")` inside `useListControls`, not in the Redux `listControlsSlice`.
+
+**Why:** `sortByHeight` is a *user preference* — the user explicitly chose a display mode and expects it to survive a page reload. It is persisted to `localStorage` via `createPersistenceMiddleware`. A name filter is *transient intent* — it belongs to a specific browsing moment. Restoring "char" on every reload would be surprising and unhelpful.
+
+**Consequence:** `filterByName` resets to `""` naturally on every component unmount/remount (i.e., page reload or navigation away and back). No cleanup needed. No Redux action, no slice modification.
+
+**Contrast:**
+
+| State | Location | Persisted | Reason |
+|-------|----------|-----------|--------|
+| `sortByHeight` | Redux (`listControlsSlice`) | Yes (localStorage) | User preference |
+| `filterByName` | Local `useState` (`useListControls`) | No | Transient — resets on reload |
+
+---
+
+### 2. Prerequisite refactor: `rawList` + `useMemo`
+
+Before adding the filter, `usePokemonList` had `sortByHeight` inside its `useEffect`. This caused the entire pokemon list to be **re-fetched from the API** every time the user toggled the sort checkbox.
+
+**Fix:** Separate fetch from transformation.
+
+- `useEffect` only runs on `selectedType` change → one network request per type selection
+- `useMemo` derives the displayed list from `rawList` (applies filter, then sort) → no network requests from UI interactions
+
+This separation is what makes both sort and filter performant. Without it, every keystroke in the filter input would trigger an API call.
+
+---
+
+### 3. `usePokemonList` overload design
+
+`filterByName` travels as a **direct parameter** to `usePokemonList`, not via Redux. This means `PokemonListSection` reads `filterByName` from `useListControls` and passes it down:
+
+```typescript
+const { filterByName, setFilterByName, ... } = useListControls();
+const { pokemonList } = usePokemonList(selectedType, filterByName);
+```
+
+The hook already had a dependency injection overload for testing (`usePokemonList(type, mockRepository)`). Adding a filter string creates an ambiguity: what is the second argument — a filter or a repository?
+
+**Solution:** Detect the type of the second argument at runtime.
+
+Four supported calling conventions sharing a single implementation:
+
+| Convention | Arguments | Used in |
+|-----------|-----------|---------|
+| `usePokemonList(type)` | 1 | Production, no filter |
+| `usePokemonList(type, filterByName)` | 2 (string) | Production, with filter |
+| `usePokemonList(type, repository)` | 2 (object) | Tests, no filter |
+| `usePokemonList(type, repository, filterByName)` | 3 | Tests, with filter |
+
+Detection logic:
+```typescript
+const isRepositoryInjected =
+  secondParam !== undefined && typeof secondParam !== "string";
+
+const filterByName =
+  typeof secondParam === "string" ? secondParam : (thirdParam ?? "");
+```
+
+**Critical detail:** The `repositoryInstance` `useMemo` must depend on `injectedRepository` (the extracted object-or-undefined), NOT on `secondParam` directly. If it depended on `secondParam`, every keystroke (changing `filterByName` = `secondParam`) would recreate the repository and the ViewModel, which would fire `useEffect` and trigger a new API fetch.
+
+```typescript
+// ✅ Correct — stable reference, not affected by filter string changes
+const injectedRepository = isRepositoryInjected
+  ? (secondParam as PokemonRepository)
+  : undefined;
+
+const repositoryInstance = useMemo(() => {
+  if (injectedRepository !== undefined) return injectedRepository;
+  return new HttpPokemonRepository(httpClient, {...});
+}, [httpClient, injectedRepository]); // ← no secondParam here
+```
+
+---
+
+### 4. Debounce inside `usePokemonList`
+
+Without debounce, the list recalculates on every keystroke. Typing "charmeleon" (10 characters) would trigger 10 `useMemo` executions, causing 10 rapid list re-renders. The visual effect is a list that flickers on every key.
+
+**Solution:** `useDebounce(filterByName, 300)` inside `usePokemonList`. The `useMemo` for `pokemonList` uses `debouncedFilter`, not `filterByName` directly. The list only updates 300ms after the user stops typing.
+
+**Why inside the hook, not in the component:** Debounce is an implementation detail of how the filter is applied internally. Components should not need to know that a filter requires debouncing. `PokemonListSection` just passes `filterByName` and receives `pokemonList`.
+
+**Why 300ms:** Industry convention for search inputs. Fast enough to feel responsive, slow enough to avoid flickering.
+
+---
+
+### 5. Transformation order: filter → sort
+
+Inside `usePokemonList`'s `useMemo`:
+
+```typescript
+let list = debouncedFilter
+  ? viewModel.filterPokemonsByName(rawList, debouncedFilter)
+  : rawList;
+if (sortByHeight) list = viewModel.sortPokemonListByHeight(list);
+return list;
+```
+
+**Why filter first:** Sort is stable within the filtered set. Filtering first reduces the set before sorting, which is slightly more efficient. More importantly, it's semantically correct: the user filters to a subset, then optionally orders that subset.
+
+**Example:** If raw list is [charizard(17), charmander(6), charmeleon(11)] and filter is "char" and sort is by height:
+1. Filter: [charizard(17), charmander(6), charmeleon(11)] — all 3 match
+2. Sort: [charmander(6), charmeleon(11), charizard(17)]
+
+If we sorted first, the intermediate [charmander(6), charmeleon(11), charizard(17)] set would then be filtered, producing the same result. But the filter-first order is the natural mental model: "show me 'char' pokemon, sorted by height."
+
+---
+
+### 6. `useDebounce` in shared infrastructure
+
+The `useDebounce<T>(value: T, delay: number): T` hook lives in `src/shared/infrastructure/react/hooks/useDebounce.ts`.
+
+**Why shared:** Debounce is a generic timing utility with no domain knowledge. It works with any type T, any delay, any use case. Keeping it in the feature would be premature specificity. Keeping it in shared makes it available to any future feature that needs debounced state.
+
+**Contract:** Input: any value + delay in ms. Output: debounced version of the value. The debounced value initializes to the same value (no initial delay). Changes propagate after `delay` ms of inactivity.
+
+---
+
+## Data Flow Diagram
+
+```
+User types "char" in <input>
+        │
+        ▼
+onChange → setFilterByName("char")   [useState in useListControls]
+        │
+        ▼
+PokemonListSection re-renders
+        │
+        ▼
+usePokemonList("fire", "char")
+        │
+        ├─► useDebounce("char", 300)
+        │         │
+        │         └─ after 300ms → debouncedFilter = "char"
+        │
+        ├─► useEffect [NO re-run — selectedType unchanged]
+        │         rawList = [charmander, charmeleon, charizard]  (unchanged)
+        │
+        └─► useMemo [re-runs when debouncedFilter changes]
+                  list = filterPokemonsByName(rawList, "char")
+                       = [charmander, charmeleon, charizard]  (all match "char")
+                  if sortByHeight → sortPokemonListByHeight(list)
+                  return list
+        │
+        ▼
+pokemonList = [charmander, charmeleon, charizard]
+        │
+        ▼
+useVirtualGridList(pokemonList, config)
+        │
+        ▼
+PokemonListGrid renders visible items
+```
+
+---
+
+## Files Changed & Why
+
+| File | Change | Why |
+|------|--------|-----|
+| `application/use-cases/filter-pokemons-by-name/FilterPokemonsByNameUseCase.ts` | Created | Pure domain use case — case-insensitive substring filter |
+| `application/use-cases/filter-pokemons-by-name/__tests__/FilterPokemonsByNameUseCase.test.ts` | Created | TDD unit tests for the use case |
+| `application/view-models/PokemonListViewModel.ts` | Added `filterPokemonsByName()` | ViewModel delegates to use case, following the sort pattern |
+| `application/view-models/__tests__/PokemonListViewModel.test.ts` | Extended | Verify ViewModel delegates correctly |
+| `shared/infrastructure/react/hooks/useDebounce.ts` | Created | Generic debounce hook used by `usePokemonList` |
+| `infrastructure/react/hooks/useListControls.ts` | Added `filterByName` + `setFilterByName` | Local state (not Redux) for transient filter value |
+| `infrastructure/react/hooks/__tests__/useListControls.test.ts` | Extended | Verify initial value and setter |
+| `infrastructure/react/hooks/usePokemonList.ts` | Added overloads, `useDebounce`, filter in `useMemo` | Core hook update — see decision 3 |
+| `infrastructure/react/hooks/__tests__/usePokemonList.filterByName.test.ts` | Created | TDD hook tests for filter behavior |
+| `PokemonListControls.tsx` | Added search input + `filterByName` props | UI: renders the `<input type="text">` with proper label |
+| `PokemonListSection.tsx` | Passes `filterByName` to hook and controls | Wires state from `useListControls` through the hook and into the UI |
+| `pages/Home/__tests__/helpers.ts` | Added `typeInNameFilter()` | User action helper following the project helper pattern |
+| `pages/Home/__tests__/Home.FilterByName.test.tsx` | Created | Integration test written first (TDD outside-in) |

--- a/src/features/pokemon-list/PokemonListControls.tsx
+++ b/src/features/pokemon-list/PokemonListControls.tsx
@@ -3,11 +3,15 @@ import React from "react";
 interface PokemonListControlsProps {
   isSortedByHeight: boolean;
   onSortChange: () => void;
+  filterByName: string;
+  onFilterByNameChange: (value: string) => void;
 }
 
 const PokemonListControls: React.FC<PokemonListControlsProps> = ({
   isSortedByHeight,
   onSortChange,
+  filterByName,
+  onFilterByNameChange,
 }) => {
   return (
     <fieldset className="my-6">
@@ -23,6 +27,17 @@ const PokemonListControls: React.FC<PokemonListControlsProps> = ({
         onChange={onSortChange}
       />
       <label htmlFor="height">By height</label>
+      <div className="mt-4">
+        <label htmlFor="search-by-name">Search by name</label>
+        <input
+          className="ml-2 border"
+          type="text"
+          id="search-by-name"
+          name="search-by-name"
+          value={filterByName}
+          onChange={(e) => onFilterByNameChange(e.target.value)}
+        />
+      </div>
     </fieldset>
   );
 };

--- a/src/features/pokemon-list/PokemonListSection.tsx
+++ b/src/features/pokemon-list/PokemonListSection.tsx
@@ -10,11 +10,16 @@ import PokemonListGrid from "./PokemonListGrid";
 const PokemonListSection = () => {
   const [searchParams] = useSearchParams();
   const selectedTypeParam = searchParams.get("type");
-  const { sortByHeight: isSortedByHeight, handleToggleSortByHeight } =
-    useListControls();
+  const {
+    sortByHeight: isSortedByHeight,
+    handleToggleSortByHeight,
+    filterByName,
+    setFilterByName,
+  } = useListControls();
 
   const { pokemonList, isLoading, isError } = usePokemonList(
-    selectedTypeParam ?? ""
+    selectedTypeParam ?? "",
+    filterByName
   );
 
   const { visibleItems, totalHeight } = useVirtualGridList(pokemonList, {
@@ -43,6 +48,8 @@ const PokemonListSection = () => {
       <PokemonListControls
         isSortedByHeight={isSortedByHeight}
         onSortChange={handleToggleSortByHeight}
+        filterByName={filterByName}
+        onFilterByNameChange={setFilterByName}
       />
       <PokemonListGrid visibleItems={visibleItems} totalHeight={totalHeight} />
     </section>

--- a/src/features/pokemon-list/application/use-cases/filter-pokemons-by-name/FilterPokemonsByNameUseCase.ts
+++ b/src/features/pokemon-list/application/use-cases/filter-pokemons-by-name/FilterPokemonsByNameUseCase.ts
@@ -1,0 +1,10 @@
+import { PokemonListItem } from "../../../domain/entities/PokemonListItem";
+
+export class FilterPokemonsByNameUseCase {
+  static execute(list: PokemonListItem[], query: string): PokemonListItem[] {
+    if (!query) return list;
+    return list.filter((p) =>
+      p.name.toLowerCase().includes(query.toLowerCase())
+    );
+  }
+}

--- a/src/features/pokemon-list/application/use-cases/filter-pokemons-by-name/__tests__/FilterPokemonsByNameUseCase.test.ts
+++ b/src/features/pokemon-list/application/use-cases/filter-pokemons-by-name/__tests__/FilterPokemonsByNameUseCase.test.ts
@@ -1,0 +1,42 @@
+import { it, expect } from "vitest";
+import { FilterPokemonsByNameUseCase } from "../FilterPokemonsByNameUseCase";
+import {
+  mockPokemonListItemBulbasaur,
+  mockPokemonListItemIvysaur,
+  mockPokemonListItemVenusaur,
+} from "../../../../__tests__/mocks";
+
+const list = [
+  mockPokemonListItemBulbasaur,
+  mockPokemonListItemIvysaur,
+  mockPokemonListItemVenusaur,
+];
+
+it("returns the full list when query is empty", () => {
+  const result = FilterPokemonsByNameUseCase.execute(list, "");
+
+  expect(result).toHaveLength(3);
+  expect(result).toEqual(list);
+});
+
+it("returns matching pokemon when query matches a name partially", () => {
+  const result = FilterPokemonsByNameUseCase.execute(list, "saur");
+
+  expect(result).toHaveLength(3);
+  expect(result[0].name).toBe("bulbasaur");
+  expect(result[1].name).toBe("ivysaur");
+  expect(result[2].name).toBe("venusaur");
+});
+
+it("filters case-insensitively", () => {
+  const result = FilterPokemonsByNameUseCase.execute(list, "BULBA");
+
+  expect(result).toHaveLength(1);
+  expect(result[0].name).toBe("bulbasaur");
+});
+
+it("returns empty array when no pokemon matches", () => {
+  const result = FilterPokemonsByNameUseCase.execute(list, "pikachu");
+
+  expect(result).toHaveLength(0);
+});

--- a/src/features/pokemon-list/application/view-models/PokemonListViewModel.ts
+++ b/src/features/pokemon-list/application/view-models/PokemonListViewModel.ts
@@ -2,6 +2,7 @@ import { PokemonRepository } from "../../domain/ports/PokemonRepository";
 import { PokemonListItem } from "../../domain/entities/PokemonListItem";
 import { GetPokemonListUseCase } from "../use-cases/get-pokemon-list/GetPokemonListUseCase";
 import { SortPokemonsByHeightUseCase } from "../use-cases/sort-pokemon-list-by-height/SortPokemonLIstByHeightUseCase";
+import { FilterPokemonsByNameUseCase } from "../use-cases/filter-pokemons-by-name/FilterPokemonsByNameUseCase";
 import { PokemonType } from "../../../../shared/domain/value-objects/PokemonType";
 
 export class PokemonListViewModel {
@@ -21,5 +22,9 @@ export class PokemonListViewModel {
 
   sortPokemonListByHeight(list: PokemonListItem[]): PokemonListItem[] {
     return SortPokemonsByHeightUseCase.execute(list);
+  }
+
+  filterPokemonsByName(list: PokemonListItem[], query: string): PokemonListItem[] {
+    return FilterPokemonsByNameUseCase.execute(list, query);
   }
 }

--- a/src/features/pokemon-list/application/view-models/__tests__/PokemonListViewModel.test.ts
+++ b/src/features/pokemon-list/application/view-models/__tests__/PokemonListViewModel.test.ts
@@ -10,6 +10,9 @@ import {
   mockPokemonListItemCharizard,
   mockPokemonListItemVulpix,
   mockPokemonListItemCharmander,
+  mockPokemonListItemBulbasaur,
+  mockPokemonListItemIvysaur,
+  mockPokemonListItemVenusaur,
 } from "../../../__tests__/mocks";
 
 it("should load pokemon list by type", async () => {
@@ -39,6 +42,41 @@ it("should return empty array when type is empty", async () => {
 
   expect(result).toEqual([]);
   expect(mockRepository.findAllByType).not.toHaveBeenCalled();
+});
+
+it("should filter pokemon list by name matching a partial query", () => {
+  const mockRepository = createMockPokemonRepository([], []);
+
+  const list = [
+    mockPokemonListItemBulbasaur,
+    mockPokemonListItemIvysaur,
+    mockPokemonListItemVenusaur,
+  ];
+
+  const viewModel = new PokemonListViewModel(mockRepository);
+
+  const result = viewModel.filterPokemonsByName(list, "saur");
+
+  expect(result).toHaveLength(3);
+  expect(result[0].name).toBe("bulbasaur");
+  expect(result[1].name).toBe("ivysaur");
+  expect(result[2].name).toBe("venusaur");
+});
+
+it("should return the full list when filter query is empty", () => {
+  const mockRepository = createMockPokemonRepository([], []);
+
+  const list = [
+    mockPokemonListItemBulbasaur,
+    mockPokemonListItemIvysaur,
+    mockPokemonListItemVenusaur,
+  ];
+
+  const viewModel = new PokemonListViewModel(mockRepository);
+
+  const result = viewModel.filterPokemonsByName(list, "");
+
+  expect(result).toHaveLength(3);
 });
 
 it("should sort pokemon list by height", () => {

--- a/src/features/pokemon-list/infrastructure/react/hooks/__tests__/useListControls.test.ts
+++ b/src/features/pokemon-list/infrastructure/react/hooks/__tests__/useListControls.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { vi, it, expect, beforeEach } from "vitest";
 import { useListControls } from "../useListControls";
 import * as reduxHooks from "../../../../../../shared/infrastructure/redux/hooks";
@@ -36,4 +36,26 @@ it("dispatches toggleSortByHeight action when handleToggleSortByHeight is called
   result.current.handleToggleSortByHeight();
 
   expect(mockDispatch).toHaveBeenCalled();
+});
+
+it("returns filterByName as empty string initially", () => {
+  vi.spyOn(reduxHooks, "useAppSelector").mockReturnValue(false);
+  vi.spyOn(reduxHooks, "useAppDispatch").mockReturnValue(vi.fn());
+
+  const { result } = renderHook(() => useListControls());
+
+  expect(result.current.filterByName).toBe("");
+});
+
+it("updates filterByName when setFilterByName is called", () => {
+  vi.spyOn(reduxHooks, "useAppSelector").mockReturnValue(false);
+  vi.spyOn(reduxHooks, "useAppDispatch").mockReturnValue(vi.fn());
+
+  const { result } = renderHook(() => useListControls());
+
+  act(() => {
+    result.current.setFilterByName("char");
+  });
+
+  expect(result.current.filterByName).toBe("char");
 });

--- a/src/features/pokemon-list/infrastructure/react/hooks/__tests__/usePokemonList.filterByName.test.ts
+++ b/src/features/pokemon-list/infrastructure/react/hooks/__tests__/usePokemonList.filterByName.test.ts
@@ -1,0 +1,80 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { vi, it, expect, beforeEach, afterEach } from "vitest";
+import usePokemonList from "../usePokemonList";
+import { testData } from "./setupTests";
+import * as reduxHooks from "../../../../../../shared/infrastructure/redux/hooks";
+
+beforeEach(() => {
+  vi.spyOn(reduxHooks, "useAppSelector").mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it("returns full list when filterByName is empty", async () => {
+  const { result } = renderHook(() =>
+    usePokemonList("grass", testData.mockRepository!, "")
+  );
+
+  await waitFor(() => {
+    expect(result.current.pokemonList).toHaveLength(3);
+  });
+});
+
+it("returns only matching pokemons when filterByName is provided", async () => {
+  const { result } = renderHook(() =>
+    usePokemonList("grass", testData.mockRepository!, "bulbasaur")
+  );
+
+  await waitFor(() => {
+    expect(result.current.pokemonList).toHaveLength(1);
+    expect(result.current.pokemonList[0].name).toBe("bulbasaur");
+  });
+});
+
+it("filters case-insensitively", async () => {
+  const { result } = renderHook(() =>
+    usePokemonList("grass", testData.mockRepository!, "SAUR")
+  );
+
+  await waitFor(() => {
+    expect(result.current.pokemonList).toHaveLength(3);
+    expect(result.current.pokemonList[0].name).toBe("bulbasaur");
+    expect(result.current.pokemonList[1].name).toBe("ivysaur");
+    expect(result.current.pokemonList[2].name).toBe("venusaur");
+  });
+});
+
+it("returns empty list when no pokemon matches the filter", async () => {
+  const { result } = renderHook(() =>
+    usePokemonList("grass", testData.mockRepository!, "pikachu")
+  );
+
+  await waitFor(() => {
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  expect(result.current.pokemonList).toHaveLength(0);
+});
+
+it("updates filtered list after debounce when filterByName changes", async () => {
+  const { result, rerender } = renderHook(
+    ({ filter }: { filter: string }) =>
+      usePokemonList("grass", testData.mockRepository!, filter),
+    { initialProps: { filter: "" } }
+  );
+
+  // Initial load (no filter)
+  await waitFor(() => {
+    expect(result.current.pokemonList).toHaveLength(3);
+  });
+
+  // Change filter — debounce fires after 300ms, waitFor polls for 1000ms
+  rerender({ filter: "bulbasaur" });
+
+  await waitFor(() => {
+    expect(result.current.pokemonList).toHaveLength(1);
+    expect(result.current.pokemonList[0].name).toBe("bulbasaur");
+  });
+});

--- a/src/features/pokemon-list/infrastructure/react/hooks/useListControls.ts
+++ b/src/features/pokemon-list/infrastructure/react/hooks/useListControls.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   useAppDispatch,
   useAppSelector,
@@ -15,8 +16,12 @@ export const useListControls = () => {
     dispatch(toggleSortByHeight());
   };
 
+  const [filterByName, setFilterByName] = useState("");
+
   return {
     sortByHeight,
     handleToggleSortByHeight,
+    filterByName,
+    setFilterByName,
   };
 };

--- a/src/features/pokemon-list/infrastructure/react/hooks/usePokemonList.ts
+++ b/src/features/pokemon-list/infrastructure/react/hooks/usePokemonList.ts
@@ -5,6 +5,7 @@ import { PokemonListViewModel } from "../../../application/view-models/PokemonLi
 import { HttpPokemonRepository } from "../../http/HttpPokemonRepository";
 import { FetchHttpClient } from "../../../../../shared/infrastructure/client/fetch/FetchHttpClient";
 import { useAppSelector } from "../../../../../shared/infrastructure/redux/hooks";
+import { useDebounce } from "../../../../../shared/infrastructure/react/hooks/useDebounce";
 
 interface UsePokemonListResult {
   pokemonList: PokemonListItem[];
@@ -12,19 +13,58 @@ interface UsePokemonListResult {
   isError: boolean;
 }
 
-// Overload for component usage (Redux internally reads sortByHeight)
+/**
+ * Hook that loads and transforms the pokemon list for the current type.
+ *
+ * ## Overload design
+ * Supports four calling conventions sharing the same implementation:
+ *
+ *   Production (no filter):      usePokemonList(selectedType)
+ *   Production (with filter):    usePokemonList(selectedType, filterByName)
+ *   Testing (with repo):         usePokemonList(selectedType, mockRepository)
+ *   Testing (repo + filter):     usePokemonList(selectedType, mockRepository, filterByName)
+ *
+ * The second param is detected at runtime:
+ *   - string  → filterByName (production)
+ *   - object  → PokemonRepository (testing / dependency injection)
+ *
+ * ## Internal separation: fetch vs. transformation
+ * `useEffect` only fetches (runs when selectedType changes).
+ * `useMemo` applies filter + sort without triggering new requests.
+ * This prevents re-fetching when the user types in the filter or toggles sort.
+ *
+ * ## Debounce
+ * filterByName is debounced 300ms internally to avoid recalculating
+ * the list on every keystroke.
+ */
+
+// Overload for component usage (no filter)
 function usePokemonList(selectedType: string): UsePokemonListResult;
 
-// Overload for testing (with repository injection)
+// Overload for component usage (with filter)
+function usePokemonList(
+  selectedType: string,
+  filterByName: string
+): UsePokemonListResult;
+
+// Overload for testing (with repository injection, no filter)
 function usePokemonList(
   selectedType: string,
   repository: PokemonRepository
 ): UsePokemonListResult;
 
+// Overload for testing (with repository injection and filter)
+function usePokemonList(
+  selectedType: string,
+  repository: PokemonRepository,
+  filterByName: string
+): UsePokemonListResult;
+
 // Implementation
 function usePokemonList(
   selectedType: string,
-  repository?: PokemonRepository
+  secondParam?: PokemonRepository | string,
+  thirdParam?: string
 ): UsePokemonListResult {
   const [rawList, setRawList] = useState<PokemonListItem[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -34,7 +74,19 @@ function usePokemonList(
     (state) => state.listControls.sortByHeight
   );
 
-  const isRepositoryInjected = repository !== undefined;
+  const isRepositoryInjected =
+    secondParam !== undefined && typeof secondParam !== "string";
+
+  const filterByName =
+    typeof secondParam === "string" ? secondParam : (thirdParam ?? "");
+
+  const debouncedFilter = useDebounce(filterByName, 300);
+
+  // Extract the injected repository separately so that changes to filterByName
+  // (secondParam as a string) never cause repositoryInstance to recreate.
+  const injectedRepository = isRepositoryInjected
+    ? (secondParam as PokemonRepository)
+    : undefined;
 
   const httpClient = useMemo(
     () => new FetchHttpClient("https://pokeapi.co/api/v2/"),
@@ -42,14 +94,14 @@ function usePokemonList(
   );
 
   const repositoryInstance = useMemo(() => {
-    if (isRepositoryInjected) {
-      return repository!;
+    if (injectedRepository !== undefined) {
+      return injectedRepository;
     }
     return new HttpPokemonRepository(httpClient, {
       typeEndpoint: "type/",
       pokemonEndpoint: "pokemon/",
     });
-  }, [httpClient, isRepositoryInjected, repository]);
+  }, [httpClient, injectedRepository]);
 
   const viewModel = useMemo(
     () => new PokemonListViewModel(repositoryInstance),
@@ -84,9 +136,12 @@ function usePokemonList(
   }, [selectedType, viewModel]);
 
   const pokemonList = useMemo(() => {
-    if (sortByHeight) return viewModel.sortPokemonListByHeight(rawList);
-    return rawList;
-  }, [rawList, sortByHeight, viewModel]);
+    let list = debouncedFilter
+      ? viewModel.filterPokemonsByName(rawList, debouncedFilter)
+      : rawList;
+    if (sortByHeight) list = viewModel.sortPokemonListByHeight(list);
+    return list;
+  }, [rawList, sortByHeight, debouncedFilter, viewModel]);
 
   return {
     pokemonList,

--- a/src/pages/Home/__tests__/Home.FilterByName.test.tsx
+++ b/src/pages/Home/__tests__/Home.FilterByName.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { expect, it } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Provider } from "react-redux";
+import Home from "../Home";
+import { store } from "../../../shared/infrastructure/redux/store";
+import { typeInNameFilter } from "./helpers";
+
+it("renders only matching pokemons when user types complete name in name filter", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for all fire type pokemon to load
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+
+    const items = within(pokemonItemList).getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+    expect(
+      within(items[0]).getByRole("heading", { level: 3, name: /charmander/i }),
+    ).toBeInTheDocument();
+  });
+
+  await typeInNameFilter("charmeleon");
+
+  // Only charmeleon should remain visible
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+
+    const items = within(pokemonItemList).getAllByRole("listitem");
+    expect(items).toHaveLength(1);
+    expect(
+      within(items[0]).getByRole("heading", { level: 3, name: /charmeleon/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+it("renders all pokemons again when user clears the name filter", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for initial full list
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  await typeInNameFilter("charmeleon");
+
+  // Filter applied — only one item
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(1);
+  });
+
+  // Clear the filter
+  await typeInNameFilter("");
+
+  // All pokemons visible again in original order
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+
+    const [itemOne, itemTwo, itemThree] =
+      within(pokemonItemList).getAllByRole("listitem");
+
+    expect(
+      within(itemOne).getByRole("heading", { level: 3, name: /charmander/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(itemTwo).getByRole("heading", { level: 3, name: /charmeleon/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(itemThree).getByRole("heading", { level: 3, name: /charizard/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Home/__tests__/helpers.ts
+++ b/src/pages/Home/__tests__/helpers.ts
@@ -1,6 +1,13 @@
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+export const typeInNameFilter = async (text: string) => {
+  const user = userEvent.setup();
+  const input = await screen.findByRole("textbox", { name: /search by name/i });
+  await user.clear(input);
+  if (text) await user.type(input, text);
+};
+
 export const clickButtonFireType = async () => {
   const user = userEvent.setup();
 

--- a/src/shared/infrastructure/react/hooks/useDebounce.ts
+++ b/src/shared/infrastructure/react/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary

Implements client-side Pokemon list filtering by name as a new feature, following the existing hexagonal architecture and TDD workflow (outside-in integration test first, then layer-by-layer unit tests).

## Key Changes

- **`Feature`** — `FilterPokemonsByNameUseCase` + `PokemonListViewModel.filterPokemonsByName()`: pure domain use case for case-insensitive substring filtering, delegated through the ViewModel following the existing sort pattern
- **`Feature`** — `useListControls`: adds `filterByName` as local `useState` (not Redux) — transient state that resets on reload, intentionally not persisted unlike `sortByHeight`
- **`Refactor`** — `usePokemonList`: extends to 4 TypeScript overloads (production/testing × with/without filter); `useDebounce` applied internally at 300ms; filter applied in `useMemo` before sort; `injectedRepository` extracted from `secondParam` to prevent re-fetches on every keystroke
- **`Feature`** — `useDebounce<T>`: generic debounce hook added to `src/shared/infrastructure/react/hooks/` for reuse across features
- **`Tests`** — Integration test `Home.FilterByName.test.tsx` written first (TDD); 5 hook unit tests in `usePokemonList.filterByName.test.ts`; ViewModel and use case unit tests — 209 tests total, all passing
- **`Docs`** — `docs/GUIDE_FILTER_BY_NAME.md`: rationale document covering 6 architectural decisions (local vs Redux state, fetch/transform separation, overload design, debounce placement, transformation order, shared infrastructure)

## Impact

✅ Filter input narrows the visible Pokemon list client-side with no additional API requests — fetch and transformation are fully decoupled via `rawList` + `useMemo`
✅ Debounce (300ms) prevents list flickering on keystrokes while keeping the input feel responsive
✅ All 209 existing tests remain green — no regressions introduced
✅ Overload design preserves backward compatibility with all existing test call sites (`usePokemonList(type, mockRepository)`)
