### PR TITLE
Improve list filter

### DIFF
--- a/src/features/pokemon-list/PokemonListSection.tsx
+++ b/src/features/pokemon-list/PokemonListSection.tsx
@@ -51,6 +51,9 @@ const PokemonListSection = () => {
         filterByName={filterByName}
         onFilterByNameChange={setFilterByName}
       />
+      {filterByName && pokemonList.length === 0 && (
+        <h2>Sorry, we cannot find Pokemons with that name</h2>
+      )}
       <PokemonListGrid visibleItems={visibleItems} totalHeight={totalHeight} />
     </section>
   );

--- a/src/features/pokemon-list/infrastructure/react/hooks/usePokemonList.ts
+++ b/src/features/pokemon-list/infrastructure/react/hooks/usePokemonList.ts
@@ -135,11 +135,18 @@ function usePokemonList(
     fetchData();
   }, [selectedType, viewModel]);
 
+  // Apply transformations: filter first, then sort. rawList is never mutated.
   const pokemonList = useMemo(() => {
-    let list = debouncedFilter
-      ? viewModel.filterPokemonsByName(rawList, debouncedFilter)
-      : rawList;
-    if (sortByHeight) list = viewModel.sortPokemonListByHeight(list);
+    let list = rawList;
+
+    if (debouncedFilter) {
+      list = viewModel.filterPokemonsByName(rawList, debouncedFilter);
+    }
+
+    if (sortByHeight) {
+      list = viewModel.sortPokemonListByHeight(list);
+    }
+
     return list;
   }, [rawList, sortByHeight, debouncedFilter, viewModel]);
 

--- a/src/pages/Home/__tests__/Home.FilterByName.test.tsx
+++ b/src/pages/Home/__tests__/Home.FilterByName.test.tsx
@@ -231,6 +231,37 @@ it("renders only charmander when filtering by suffix of its name", async () => {
   });
 });
 
+it("renders empty state message when filter matches no pokemons", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for all fire type pokemon to load
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  // "pikachu" is not a fire type pokemon — no results expected
+  await typeInNameFilter("pikachu");
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole("heading", { level: 2, name: /sorry.*cannot find/i }),
+    ).toBeInTheDocument();
+  });
+});
+
 it("renders all pokemons again when user clears the name filter", async () => {
   render(
     <Provider store={store}>

--- a/src/pages/Home/__tests__/Home.FilterByName.test.tsx
+++ b/src/pages/Home/__tests__/Home.FilterByName.test.tsx
@@ -48,6 +48,80 @@ it("renders only matching pokemons when user types complete name in name filter"
   });
 });
 
+it("renders only matching pokemon when user types partial name in name filter", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for all fire type pokemon to load
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  // "mander" is a suffix of "charmander" only — not present in "charmeleon" or "charizard"
+  await typeInNameFilter("mander");
+
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+
+    const items = within(pokemonItemList).getAllByRole("listitem");
+    expect(items).toHaveLength(1);
+    expect(
+      within(items[0]).getByRole("heading", { level: 3, name: /charmander/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+it("renders only matching pokemon when user types uppercase name in name filter", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for all fire type pokemon to load
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  await typeInNameFilter("CHARMELEON");
+
+  // Only charmeleon should remain visible despite uppercase input
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+
+    const items = within(pokemonItemList).getAllByRole("listitem");
+    expect(items).toHaveLength(1);
+    expect(
+      within(items[0]).getByRole("heading", { level: 3, name: /charmeleon/i }),
+    ).toBeInTheDocument();
+  });
+});
+
 it("renders all pokemons again when user clears the name filter", async () => {
   render(
     <Provider store={store}>

--- a/src/pages/Home/__tests__/Home.FilterByName.test.tsx
+++ b/src/pages/Home/__tests__/Home.FilterByName.test.tsx
@@ -122,6 +122,115 @@ it("renders only matching pokemon when user types uppercase name in name filter"
   });
 });
 
+it("renders charmander when filtering by prefix of its name", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for all fire type pokemon to load
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  // "char" is a shared prefix — charmander must be in results alongside others
+  await typeInNameFilter("char");
+
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(
+      within(pokemonItemList).getByRole("heading", {
+        level: 3,
+        name: /charmander/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});
+
+it("renders only charmander when filtering by middle substring of its name", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for all fire type pokemon to load
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  // "man" appears in "char-MAN-der" only
+  await typeInNameFilter("man");
+
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    const items = within(pokemonItemList).getAllByRole("listitem");
+    expect(items).toHaveLength(1);
+    expect(
+      within(items[0]).getByRole("heading", { level: 3, name: /charmander/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+it("renders only charmander when filtering by suffix of its name", async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/?type=fire"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+
+  const contentArea = within(screen.getByRole("main")).getByRole("article");
+
+  // Wait for all fire type pokemon to load
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    expect(within(pokemonItemList).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  // "der" is the suffix of "charman-DER" only
+  await typeInNameFilter("der");
+
+  await waitFor(() => {
+    const pokemonItemList = within(contentArea).getByRole("list", {
+      name: /pokemon list/i,
+    });
+    const items = within(pokemonItemList).getAllByRole("listitem");
+    expect(items).toHaveLength(1);
+    expect(
+      within(items[0]).getByRole("heading", { level: 3, name: /charmander/i }),
+    ).toBeInTheDocument();
+  });
+});
+
 it("renders all pokemons again when user clears the name filter", async () => {
   render(
     <Provider store={store}>


### PR DESCRIPTION

## Summary

Improves the filter-by-name integration test suite with full substring coverage and adds an empty state message when no Pokémon match the active filter. Includes a readability refactor of the transformation pipeline in `usePokemonList`.

## Key Changes

- **Tests:** Added 6 new integration test cases to `Home.FilterByName.test.tsx` covering partial name (suffix), case-insensitive input, prefix/middle/suffix substring positions, empty state message, and filter clear
- **Feature:** `PokemonListSection.tsx` renders `<h2>Sorry, we cannot find Pokemons with that name</h2>` when `filterByName` is non-empty and `pokemonList` is empty
- **Refactor:** Replaced ternary expression with explicit `if/else` blocks in the `pokemonList` `useMemo` inside `usePokemonList.ts` for improved readability
- **Docs:** Added inline comment clarifying transformation order (`filter → sort`) and the immutability of `rawList`

## Impact

✅ Filter-by-name integration suite grows from 2 to 8 tests, covering all substring match positions  
✅ Users now receive clear feedback when a name filter returns no results  
✅ Transformation pipeline logic in `usePokemonList` is easier to read and reason about at a glance  
