### PR TITLE
Fix filter text visibility

### DIFF
--- a/src/features/pokemon-list/PokemonListControls.tsx
+++ b/src/features/pokemon-list/PokemonListControls.tsx
@@ -31,7 +31,7 @@ const PokemonListControls: React.FC<PokemonListControlsProps> = ({
         <label htmlFor="search-by-name">Search by name</label>
         <input
           className="ml-2 border"
-          type="text"
+          type="search"
           id="search-by-name"
           name="search-by-name"
           value={filterByName}

--- a/src/features/pokemon-list/PokemonListControls.tsx
+++ b/src/features/pokemon-list/PokemonListControls.tsx
@@ -30,7 +30,7 @@ const PokemonListControls: React.FC<PokemonListControlsProps> = ({
       <div className="mt-4">
         <label htmlFor="search-by-name">Search by name</label>
         <input
-          className="ml-2 border"
+          className="ml-2 border text-gray-900"
           type="search"
           id="search-by-name"
           name="search-by-name"

--- a/src/features/pokemon-list/PokemonListSection.tsx
+++ b/src/features/pokemon-list/PokemonListSection.tsx
@@ -52,7 +52,7 @@ const PokemonListSection = () => {
         onFilterByNameChange={setFilterByName}
       />
       {filterByName && pokemonList.length === 0 && (
-        <h2>Sorry, we cannot find Pokemons with that name</h2>
+        <output>Sorry, we cannot find Pokémon with that name</output>
       )}
       <PokemonListGrid visibleItems={visibleItems} totalHeight={totalHeight} />
     </section>

--- a/src/pages/Home/__tests__/Home.FilterByName.test.tsx
+++ b/src/pages/Home/__tests__/Home.FilterByName.test.tsx
@@ -256,9 +256,8 @@ it("renders empty state message when filter matches no pokemons", async () => {
   await typeInNameFilter("pikachu");
 
   await waitFor(() => {
-    expect(
-      screen.getByRole("heading", { level: 2, name: /sorry.*cannot find/i }),
-    ).toBeInTheDocument();
+    const statusEl = screen.getByRole("status");
+    expect(statusEl).toHaveTextContent(/sorry.*cannot find/i);
   });
 });
 

--- a/src/pages/Home/__tests__/helpers.ts
+++ b/src/pages/Home/__tests__/helpers.ts
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 
 export const typeInNameFilter = async (text: string) => {
   const user = userEvent.setup();
-  const input = await screen.findByRole("textbox", { name: /search by name/i });
+  const input = await screen.findByRole("searchbox", { name: /search by name/i });
   await user.clear(input);
   if (text) await user.type(input, text);
 };


### PR DESCRIPTION

## Summary

Applies accessibility fixes to the filter-by-name feature following a semantic audit: replaces an incorrect `<h2>` empty state with a native `<output>` element and upgrades the search input to use the correct HTML type.

## Key Changes

- **Fix:** `PokemonListSection.tsx` — replaced `<h2>` with `<output>` for the empty state message; `<output>` carries implicit `role="status"` and `aria-live="polite"`, ensuring screen readers announce the feedback dynamically without ARIA attributes
- **Fix:** `PokemonListControls.tsx` — changed `type="text"` → `type="search"` on the name filter input, exposing `role="searchbox"` to assistive technology and triggering the correct keyboard on mobile
- **Fix:** `PokemonListControls.tsx` — added `text-gray-900` to the input className; the previous `ml-2 border` left text color unset, making typed text invisible
- **Tests:** `Home.FilterByName.test.tsx` — updated empty state assertion from `getByRole("heading", { level: 2 })` to `getByRole("status")` + `toHaveTextContent` to match the new `<output>` semantics
- **Tests:** `helpers.ts` — updated `typeInNameFilter` to query by `role="searchbox"` instead of `role="textbox"` after the `type="search"` change

## Impact

✅ Empty state message is now announced by screen readers when it appears dynamically (`aria-live="polite"` via native `<output>`)  
✅ Search input is semantically typed, enabling correct assistive technology labelling and mobile keyboard  
✅ Input text is visible for all users regardless of inherited theme or color scheme  
